### PR TITLE
add app gallery page

### DIFF
--- a/content/en/docs/Badges/MCH2022/software-development/gallery.md
+++ b/content/en/docs/Badges/MCH2022/software-development/gallery.md
@@ -1,0 +1,12 @@
+---
+title: "App gallery"
+linkTitle: "App gallery"
+nodateline: true
+weight: 99
+---
+
+If you have made a cool badge app that you want to show, [email a picture](mailto:floor.venture.select.decide.symbol@addtodropbox.com) 
+
+<script type="text/javascript" src="https://www.dropbox.com/static/api/2/dropins.js" id="dropboxjs" data-app-key="gjfaiofzpyh2yb4"></script>
+
+<a href="https://www.dropbox.com/sh/ru8ldfg3hm6mp8s/AACwfmqMsqSPPkTD3Yg2jLkja?dl=0" class="dropbox-embed" data-height="800px" data-folder-view="grid"></a>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/168609/179798154-b27a0f67-b027-4119-873d-9798d4d27e14.png)

Adds a dropbox folder that people can email pictures to of their cool hacks.

It's linked to my dropbox, in case anyone wants to make like an "official" account or something. I have a few GB of space so if people are nice and just email me a few badge pictures it should be fine.

We'll see if this leads to all sorts of spam and abuse or people are nice about it. In that case we could remove the email and only show it at the badge workshop so that people at the workshop can email stuff they made without the entire internet spamming me.

After the camp we could convert it to a static page.