### PR TITLE
Fix WS2812 Example

### DIFF
--- a/content/en/docs/Badges/MCH2022/software-development/api/ws2812.md
+++ b/content/en/docs/Badges/MCH2022/software-development/api/ws2812.md
@@ -39,7 +39,7 @@ Setting the LEDs is pretty straightforward: Set up an array of
 A minimal example to set all LEDs to red:
 
 ```
-  uint8_t red[] = {255,0,0,255,0,0,255,0,0,255,0,0,255,0,0};
+  uint8_t red[] = {0,255,0,0,255,0,0,255,0,0,255,0,0,255,0};
   // turn on LED power
   gpio_set_direction(GPIO_SD_PWR, GPIO_MODE_OUTPUT);
   gpio_set_level(GPIO_SD_PWR, 1);


### PR DESCRIPTION
When you run the example, the LEDs will light up green. Now they should be red.