### PR TITLE
Update _index.md 404 link to fpga page

### DIFF
--- a/content/en/docs/Badges/MCH2022/software-development/fpga/fpga-getting-started/_index.md
+++ b/content/en/docs/Badges/MCH2022/software-development/fpga/fpga-getting-started/_index.md
@@ -211,7 +211,7 @@ expanded upon or left abandoned with good intentions of finishing it up
 before MCH2022. \*cough\*
 
 If it's not done, either read the [more about advanced
-examples](../fpga) or head over to the [fpga
+examples](https://www.badge.team/docs/badges/mch2022/software-development/fpga) or head over to the [fpga
 repo](https://github.com/badgeteam/mch2022-firmware-ice40/tree/master/projects),
 there is a lot of information there. Also, come by the workshops at the
 camp to chat.


### PR DESCRIPTION
(../fpga)  was a dead link -> resulted in " https://www.badge.team/docs/badges/mch2022/software-development/fpga/fpga"  yes twice "fpga" at the end -> 404
 changed to (https://www.badge.team/docs/badges/mch2022/software-development/fpga)