### PR TITLE
Move CD to Hugo 0.124.1

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -25,9 +25,9 @@ jobs:
           submodules: true
 
       - name: Setup Hugo
-        uses: peaceiris/actions-hugo@v2
+        uses: peaceiris/actions-hugo@v3
         with:
-          hugo-version: '0.111.3'
+          hugo-version: '0.124.1'
           extended: true
 
       - name: Build

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,0 @@
----
-install:
-  - curl -LO https://github.com/gohugoio/hugo/releases/download/v0.74.3/hugo_0.74.3_Linux-64bit.deb
-  - sudo dpkg -i hugo_0.74.3_Linux-64bit.deb
-
-script:
-  - hugo


### PR DESCRIPTION
Move the website Continuous Delivery Github action to Hugo 0.124.1. 

Tested locally on Debian Testing. 