### PR TITLE
Replace deploy action with another one

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -33,12 +33,13 @@ jobs:
       - name: Build
         run: bash build.sh
 
-      - name: Deploy with Rsync
-        uses: SamKirkland/web-deploy@v1
+      - name: Deploy to Server
+        uses: easingthemes/ssh-deploy@main
         with:
-          source-path: './public/'
-          target-server: ${{ vars.HOST }}
-          ssh-port:      ${{ vars.SSH_PORT }}
-          remote-user:   ${{ vars.SSH_USER }}
-          private-ssh-key: ${{ secrets.SSH_PRIVATE_KEY }}
-          destination-path: ${{ vars.WEBROOT }}
+          SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
+          ARGS: "-rlgoDzvc -i --delete"
+          SOURCE: './public/'
+          REMOTE_HOST: ${{ vars.HOST }}
+          REMOTE_USER: ${{ vars.SSH_USER }}
+          REMOTE_PORT: ${{ vars.SSH_PORT }}
+          TARGET: ${{ vars.WEBROOT }}


### PR DESCRIPTION
This PR updates the outdated, yet still functional, deploy action. By my first overview, the rsync options should be in the same scope of functionality. Not exactly sure how to test this as it touches a specific host and it would be wise to make a backup on the host before I'd guess. 

Related to #114 