### PR TITLE
Use legal entity name Stichting Badge.Team in license metadata

### DIFF
--- a/LICENSES/LicenseRef-Allnet.txt
+++ b/LICENSES/LicenseRef-Allnet.txt
@@ -2,7 +2,7 @@ LicenseRef-Allnet
 
 The "ALLNET GmbH Computersysteme" name and logo are trademarks of ALLNET GmbH Computersysteme.
 The logo image file(s) in this repository are the property of ALLNET GmbH Computersysteme and are
-included solely to identify ALLNET GmbH Computersysteme as a sponsor/partner of Badge.team events.
+included solely to identify ALLNET GmbH Computersysteme as a sponsor/partner of Stichting Badge.Team.
 All rights reserved by the trademark owner. They are NOT covered by the
 project's own license (CC-BY-4.0 / MIT) and may not be reused, modified or
 redistributed outside this documentation context without permission from the

--- a/LICENSES/LicenseRef-Bosch.txt
+++ b/LICENSES/LicenseRef-Bosch.txt
@@ -2,7 +2,7 @@ LicenseRef-Bosch
 
 The "Robert Bosch GmbH" name and logo are trademarks of Robert Bosch GmbH.
 The logo image file(s) in this repository are the property of Robert Bosch GmbH and are
-included solely to identify Robert Bosch GmbH as a sponsor/partner of Badge.team events.
+included solely to identify Robert Bosch GmbH as a sponsor/partner of Stichting Badge.Team.
 All rights reserved by the trademark owner. They are NOT covered by the
 project's own license (CC-BY-4.0 / MIT) and may not be reused, modified or
 redistributed outside this documentation context without permission from the

--- a/LICENSES/LicenseRef-Diodes.txt
+++ b/LICENSES/LicenseRef-Diodes.txt
@@ -1,7 +1,7 @@
 LicenseRef-Diodes
 
 This is a third-party component datasheet / application note, copyright Diodes Incorporated.
-It is redistributed here as hardware reference documentation for a Badge.team
+It is redistributed here as hardware reference documentation for a Stichting Badge.Team
 badge. All rights reserved by Diodes Incorporated. This document is NOT covered by the
 project's own license (CC-BY-4.0 / MIT). Redistribution terms are those of the
 original manufacturer.

--- a/LICENSES/LicenseRef-Espressif.txt
+++ b/LICENSES/LicenseRef-Espressif.txt
@@ -2,7 +2,7 @@ LicenseRef-Espressif
 
 The "Espressif Systems (Shanghai) Co., Ltd." name and logo are trademarks of Espressif Systems (Shanghai) Co., Ltd..
 The logo image file(s) in this repository are the property of Espressif Systems (Shanghai) Co., Ltd. and are
-included solely to identify Espressif Systems (Shanghai) Co., Ltd. as a sponsor/partner of Badge.team events.
+included solely to identify Espressif Systems (Shanghai) Co., Ltd. as a sponsor/partner of Stichting Badge.Team.
 All rights reserved by the trademark owner. They are NOT covered by the
 project's own license (CC-BY-4.0 / MIT) and may not be reused, modified or
 redistributed outside this documentation context without permission from the

--- a/LICENSES/LicenseRef-Freescale.txt
+++ b/LICENSES/LicenseRef-Freescale.txt
@@ -1,7 +1,7 @@
 LicenseRef-Freescale
 
 This is a third-party component datasheet / application note, copyright Freescale Semiconductor, Inc. (now NXP Semiconductors).
-It is redistributed here as hardware reference documentation for a Badge.team
+It is redistributed here as hardware reference documentation for a Stichting Badge.Team
 badge. All rights reserved by Freescale Semiconductor, Inc. (now NXP Semiconductors). This document is NOT covered by the
 project's own license (CC-BY-4.0 / MIT). Redistribution terms are those of the
 original manufacturer.

--- a/LICENSES/LicenseRef-GoodDisplay.txt
+++ b/LICENSES/LicenseRef-GoodDisplay.txt
@@ -1,7 +1,7 @@
 LicenseRef-GoodDisplay
 
 This is a third-party component datasheet / application note, copyright the e-paper display manufacturer (Good Display / Dalian Good Display Co., Ltd.).
-It is redistributed here as hardware reference documentation for a Badge.team
+It is redistributed here as hardware reference documentation for a Stichting Badge.Team
 badge. All rights reserved by the e-paper display manufacturer (Good Display / Dalian Good Display Co., Ltd.). This document is NOT covered by the
 project's own license (CC-BY-4.0 / MIT). Redistribution terms are those of the
 original manufacturer.

--- a/LICENSES/LicenseRef-Lattice.txt
+++ b/LICENSES/LicenseRef-Lattice.txt
@@ -2,7 +2,7 @@ LicenseRef-Lattice
 
 The "Lattice Semiconductor Corporation" name and logo are trademarks of Lattice Semiconductor Corporation.
 The logo image file(s) in this repository are the property of Lattice Semiconductor Corporation and are
-included solely to identify Lattice Semiconductor Corporation as a sponsor/partner of Badge.team events.
+included solely to identify Lattice Semiconductor Corporation as a sponsor/partner of Stichting Badge.Team.
 All rights reserved by the trademark owner. They are NOT covered by the
 project's own license (CC-BY-4.0 / MIT) and may not be reused, modified or
 redistributed outside this documentation context without permission from the

--- a/LICENSES/LicenseRef-Nordic.txt
+++ b/LICENSES/LicenseRef-Nordic.txt
@@ -2,7 +2,7 @@ LicenseRef-Nordic
 
 The "Nordic Semiconductor ASA" name and logo are trademarks of Nordic Semiconductor ASA.
 The logo image file(s) in this repository are the property of Nordic Semiconductor ASA and are
-included solely to identify Nordic Semiconductor ASA as a sponsor/partner of Badge.team events.
+included solely to identify Nordic Semiconductor ASA as a sponsor/partner of Stichting Badge.Team.
 All rights reserved by the trademark owner. They are NOT covered by the
 project's own license (CC-BY-4.0 / MIT) and may not be reused, modified or
 redistributed outside this documentation context without permission from the

--- a/LICENSES/LicenseRef-Procolix.txt
+++ b/LICENSES/LicenseRef-Procolix.txt
@@ -2,7 +2,7 @@ LicenseRef-Procolix
 
 The "ProcoliX B.V." name and logo are trademarks of ProcoliX B.V..
 The logo image file(s) in this repository are the property of ProcoliX B.V. and are
-included solely to identify ProcoliX B.V. as a sponsor/partner of Badge.team events.
+included solely to identify ProcoliX B.V. as a sponsor/partner of Stichting Badge.Team.
 All rights reserved by the trademark owner. They are NOT covered by the
 project's own license (CC-BY-4.0 / MIT) and may not be reused, modified or
 redistributed outside this documentation context without permission from the

--- a/LICENSES/LicenseRef-RaspberryPi.txt
+++ b/LICENSES/LicenseRef-RaspberryPi.txt
@@ -2,7 +2,7 @@ LicenseRef-RaspberryPi
 
 The "Raspberry Pi Ltd" name and logo are trademarks of Raspberry Pi Ltd.
 The logo image file(s) in this repository are the property of Raspberry Pi Ltd and are
-included solely to identify Raspberry Pi Ltd as a sponsor/partner of Badge.team events.
+included solely to identify Raspberry Pi Ltd as a sponsor/partner of Stichting Badge.Team.
 All rights reserved by the trademark owner. They are NOT covered by the
 project's own license (CC-BY-4.0 / MIT) and may not be reused, modified or
 redistributed outside this documentation context without permission from the

--- a/LICENSES/LicenseRef-TopPower.txt
+++ b/LICENSES/LicenseRef-TopPower.txt
@@ -1,7 +1,7 @@
 LicenseRef-TopPower
 
 This is a third-party component datasheet / application note, copyright NanJing Top Power ASIC Corp..
-It is redistributed here as hardware reference documentation for a Badge.team
+It is redistributed here as hardware reference documentation for a Stichting Badge.Team
 badge. All rights reserved by NanJing Top Power ASIC Corp.. This document is NOT covered by the
 project's own license (CC-BY-4.0 / MIT). Redistribution terms are those of the
 original manufacturer.

--- a/LICENSES/LicenseRef-deFEEST.txt
+++ b/LICENSES/LicenseRef-deFEEST.txt
@@ -2,7 +2,7 @@ LicenseRef-deFEEST
 
 The "deFEEST" name and logo are trademarks of deFEEST.
 The logo image file(s) in this repository are the property of deFEEST and are
-included solely to identify deFEEST as a sponsor/partner of Badge.team events.
+included solely to identify deFEEST as a sponsor/partner of Stichting Badge.Team.
 All rights reserved by the trademark owner. They are NOT covered by the
 project's own license (CC-BY-4.0 / MIT) and may not be reused, modified or
 redistributed outside this documentation context without permission from the

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -1,7 +1,7 @@
 version = 1
 
 # ---------------------------------------------------------------------------
-# Badge.team website — REUSE / SPDX metadata (spec 3.3)
+# Stichting Badge.Team website — REUSE / SPDX metadata (spec 3.3)
 #
 # Buckets:
 #   * Code (theme, config, scripts, tooling) .......... MIT
@@ -29,13 +29,13 @@ path = [
     ".gitignore",
     ".gitmodules",
 ]
-SPDX-FileCopyrightText = "Badge.team"
+SPDX-FileCopyrightText = "Stichting Badge.Team"
 SPDX-License-Identifier = "MIT"
 
 # ---- Root license file (the CC-BY-4.0 text itself) ------------------------
 [[annotations]]
 path = "LICENSE"
-SPDX-FileCopyrightText = "Badge.team"
+SPDX-FileCopyrightText = "Stichting Badge.Team"
 SPDX-License-Identifier = "CC-BY-4.0"
 
 # ---- Content: documentation, blog, own images and badge artwork (CC-BY) ---
@@ -45,7 +45,7 @@ path = [
     "static/**",
     "assets/icons/**",
 ]
-SPDX-FileCopyrightText = "Badge.team"
+SPDX-FileCopyrightText = "Stichting Badge.Team"
 SPDX-License-Identifier = "CC-BY-4.0"
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Aligns all REUSE copyright metadata to the legal entity **Stichting Badge.Team**, following the earlier correction to `LicenseRef-Mollerup.txt` (by @NightOwlNL / @renzenicolai).

- `REUSE.toml` — the three `SPDX-FileCopyrightText` fields (code, content, root LICENSE) and the header comment.
- All sponsor `LicenseRef-*.txt` — "sponsor/partner of Badge.team events." → "sponsor/partner of Stichting Badge.Team." (matches Mollerup).
- All datasheet `LicenseRef-*.txt` — "for a Badge.team badge" → "for a Stichting Badge.Team badge".

`reuse lint` passes. No file's actual license or copyright holder changes — only the project entity name is made consistent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)