### PR TITLE
Update MeshCore links to meshcore.io

### DIFF
--- a/content/en/docs/Badges/Bornhack 2026/_index.md
+++ b/content/en/docs/Badges/Bornhack 2026/_index.md
@@ -11,7 +11,7 @@ weight: -2026
 
 The BornHack 2026 badge is the **Cyber Ægg**: an egg-shaped, low-power hacker badge inspired by the 90's Tamagotchi. It is designed to run for the entire duration of the BornHack camp on a single battery charge, while keeping you connected to everyone else on the field over a long-range LoRa mesh.
 
-Under the playful shell it is a serious little radio computer. A Nordic nRF52840 drives a 1.54 inch black/red/white e-paper display, talks Bluetooth Low Energy to your phone, emulates an NFC tag on its back, and reaches the wider [MeshCore](https://meshcore.co.uk/) network through a dedicated SX1262 LoRa radio. To keep you entertained between messages there is **BornPets**, a virtual pet with a handful of mini-games.
+Under the playful shell it is a serious little radio computer. A Nordic nRF52840 drives a 1.54 inch black/red/white e-paper display, talks Bluetooth Low Energy to your phone, emulates an NFC tag on its back, and reaches the wider [MeshCore](https://meshcore.io/) network through a dedicated SX1262 LoRa radio. To keep you entertained between messages there is **BornPets**, a virtual pet with a handful of mini-games.
 
 <p align="center">
   <img src="badge-front.png" style="width: 45%; margin: 0 1%;"/>
@@ -24,7 +24,7 @@ Under the playful shell it is a serious little radio computer. A Nordic nRF52840
 * Egg-shaped badge inspired by the classic Tamagotchi
 * Nordic **nRF52840** microcontroller (BLE + USB + NFC)
 * 1.54" **152 × 152** black/red/white e-paper display
-* **SX1262** LoRa radio, part of the [MeshCore](https://meshcore.co.uk/) mesh network
+* **SX1262** LoRa radio, part of the [MeshCore](https://meshcore.io/) mesh network
 * Bluetooth Low Energy companion connection to the MeshCore app
 * NFC tag on the back for location-based games and station taps
 * 5-way joystick, `Select` / `Execute` / `Cancel` buttons, RGB LED and a piezo buzzer

--- a/content/en/docs/Badges/Bornhack 2026/getting-started/_index.md
+++ b/content/en/docs/Badges/Bornhack 2026/getting-started/_index.md
@@ -49,7 +49,7 @@ The interface is a carousel — **Left** / **Right** cycles through the top-leve
 
 ## Pair with the MeshCore app
 
-The badge speaks the [MeshCore](https://meshcore.co.uk/) companion protocol over Bluetooth Low Energy. Install the **MeshCore** app on Android / iOS, or open <https://app.meshcore.nz/> in a browser that supports Web Bluetooth (Chrome / Edge on desktop or Android).
+The badge speaks the [MeshCore](https://meshcore.io/) companion protocol over Bluetooth Low Energy. Install the **MeshCore** app on Android / iOS, or open <https://app.meshcore.nz/> in a browser that supports Web Bluetooth (Chrome / Edge on desktop or Android).
 
 1. Power the badge with USB **unplugged** — Bluetooth is disabled while USB is connected.
 2. In the app, scan for devices. Your badge advertises as **`Cyber Ægg XXYY`**, where `XXYY` is four hex characters unique to your badge.

--- a/content/en/docs/Badges/Bornhack 2026/hardware/_index.md
+++ b/content/en/docs/Badges/Bornhack 2026/hardware/_index.md
@@ -49,7 +49,7 @@ Bluetooth Low Energy is provided directly by the nRF52840. It operates in the 2.
 
 ## LoRa
 
-Long-range connectivity is provided by a dedicated Semtech **SX1262** radio with the matching/balun circuit specified in the Semtech application note *AN1200.54*. The LoRa antenna is a Texas Instruments design documented in [SWRA416](https://www.ti.com/lit/an/swra416/swra416.pdf). On the network side the badge speaks [MeshCore](https://meshcore.co.uk/), so it can join the wider camp mesh out of the box.
+Long-range connectivity is provided by a dedicated Semtech **SX1262** radio with the matching/balun circuit specified in the Semtech application note *AN1200.54*. The LoRa antenna is a Texas Instruments design documented in [SWRA416](https://www.ti.com/lit/an/swra416/swra416.pdf). On the network side the badge speaks [MeshCore](https://meshcore.io/), so it can join the wider camp mesh out of the box.
 
 ## NFC
 

--- a/content/en/docs/Badges/Bornhack 2026/mesh/_index.md
+++ b/content/en/docs/Badges/Bornhack 2026/mesh/_index.md
@@ -5,7 +5,7 @@ nodateline: true
 weight: 3
 ---
 
-The badge has a LoRa SX1262 radio and speaks the **[MeshCore](https://meshcore.co.uk/)** mesh protocol. Other badges, MeshCore phones and standalone repeaters all appear as peers. Four carousel screens are mesh-related: **PMs**, **Channel**, **Adverts** and **My QR**, backed by the **Contacts** list.
+The badge has a LoRa SX1262 radio and speaks the **[MeshCore](https://meshcore.io/)** mesh protocol. Other badges, MeshCore phones and standalone repeaters all appear as peers. Four carousel screens are mesh-related: **PMs**, **Channel**, **Adverts** and **My QR**, backed by the **Contacts** list.
 
 ## Getting on the same network
 


### PR DESCRIPTION
Swaps `meshcore.co.uk` → `meshcore.io` across the Bornhack 2026 docs (5 links in 4 files). The `app.meshcore.nz` app URL is left as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)