### PR TITLE
Sync Bornhack 2026 docs with latest firmware

### DIFF
--- a/content/en/docs/Badges/Bornhack 2026/clock/_index.md
+++ b/content/en/docs/Badges/Bornhack 2026/clock/_index.md
@@ -24,7 +24,7 @@ Two switchable watch faces — digital and analog. A small bell icon in the head
 The badge has no backup battery for its real-time clock, so the wall clock resets to **None** on every boot and reads "Clock not set" until you set it. Two ways:
 
 * **MeshCore app over Bluetooth** — the phone pushes its time. The easy path.
-* **Mesh time advert** — stand near a synced LoRa repeater and the badge picks the time up over the air.
+* **Mesh time advert** — stand near a synced LoRa repeater and the badge picks the time up over the air. On-air time is only accepted from a *trusted* source: a signature-verified repeater / companion advert or a channel you hold the key for. A crowd of other badges won't set your clock.
 
 Set the timezone once under **Main → Settings → Timezone** — it persists across reboots (default `+2`, CEST for BornHack).
 
@@ -89,3 +89,16 @@ You can use the official BornHack programme `.ics` straight from <https://bornha
 {{% alert title="Limits" color="info" %}}
 Up to 31 events are stored. Multi-day events are clamped to end at 23:59 on their start day (e-paper doesn't draw events spanning days). All events are RAM-only and re-imported on every boot from `ALARMS.ICS`.
 {{% /alert %}}
+
+### Import limits & quirks
+
+The parser is deliberately minimal. If events are missing or look odd, one of these is usually why:
+
+* **File size: 16 KiB max.** Anything past that is silently cut off mid-event. A full conference programme easily exceeds this — trim it first with the firmware's [`scripts/strip_ics.py`](https://codeberg.org/Ranzbak/bornhack-firmware-2026/src/branch/main/scripts/strip_ics.py) (drops `DESCRIPTION`/`UID`/etc. and supports `--from` / `--to` / `--max` to select a range).
+* **31 events max.** Import stops quietly at the cap; later events in the file never appear.
+* **No recurrence.** `RRULE` is ignored — a repeating event imports as its first occurrence only. Export "expanded" per-occurrence ICS instead (the BornHack programme already is).
+* **No all-day events.** A DATE-only `DTSTART` is dropped without warning. Give the event a real start time.
+* **ASCII only.** Non-ASCII characters in titles are stripped, not transliterated (`Æ`, accents and emoji simply vanish).
+* **Timezones.** Only `Z`-suffixed (UTC) timestamps are shifted to local time — always by the built-in default of **UTC+2** (right for BornHack), because the import runs before your persisted timezone setting is applied. Floating and `TZID=`-zoned times are taken as-is. When in doubt, export in UTC.
+* **Fired events disappear from the Calendar until reboot.** Imported events are one-shot alarms: once one has fired it no longer shows on the grid or day view. Rebooting re-imports everything.
+* **Edits apply at boot only.** Replace `ALARMS.ICS`, eject the drive properly, then power-cycle the badge.

--- a/content/en/docs/Badges/Bornhack 2026/faq/_index.md
+++ b/content/en/docs/Badges/Bornhack 2026/faq/_index.md
@@ -12,17 +12,29 @@ Quick answers to the things people most often hit with the Cyber Ægg. If none o
 **The badge won't wake / the display stays blank.**
 Plug in USB-C. If the LED never blinks, hold **Execute** while plugging in and re-flash the firmware with `dfu-util` — see [Getting started → Firmware update](../getting-started/#firmware-update).
 
+**A fresh flash (or factory reset) shows the factory test, then a "ready to ship" screen — and hangs there.**
+By design. After an all-pass self-test the badge stamps its pass flag, draws the ship screen and halts (green LED pulsing). Power-cycle once more; the second boot skips the test and starts the app.
+
+**"Battery voltage critical" screen at boot, the badge goes no further.**
+The cell measured below 3.0 V at power-on, so the firmware halts to protect it. Charging is hardware-controlled and continues anyway — leave USB plugged in for a while, then power-cycle manually (the badge does not reboot itself off this screen).
+
 **The clock keeps resetting on every reboot.**
-Expected — there is no battery-backed RTC. Pair over Bluetooth with the MeshCore app once per boot, or wait until you are near a synced mesh repeater that advertises the time. See [Getting started → Set the time](../getting-started/#set-the-time).
+Expected — there is no battery-backed RTC. Pair over Bluetooth with the MeshCore app once per boot, or wait until you are near a synced mesh repeater. Note that on-air time is only accepted from a **trusted source** — a signature-verified repeater / companion advert or a channel you hold the key for. A crowd of other badges won't set your clock; a phone pairing always will.
 
 **Bluetooth isn't visible / I can't pair.**
-Bluetooth is disabled whenever USB is connected. **Unplug the badge** and try again.
+Two things to check: USB is plugged in (Bluetooth is disabled whenever USB is connected — unplug), or Bluetooth was switched off in **Main → Settings → Bluetooth** (the toggle persists across reboots; set it back to `BLE: ON`).
 
 **My alarm never fired.**
-The clock hasn't been set yet this boot — alarms only fire once the time is known. Set the time first.
+The clock hasn't been set yet this boot — alarms only fire once the time is known. If the clock *is* set, check the alarm's **Days** field — `None` never fires, and a Weekdays / Weekends / Custom mask only fires on matching days (the header bell shows for any enabled alarm regardless of its day mask).
 
 **No mesh peers show up.**
 Walk around — LoRa range varies with terrain and antenna orientation. Also check your LoRa preset under **Main → Settings → LoRa Radio**; it must match the rest of the local mesh. See [Mesh](../mesh/).
+
+**I reformatted the badge's USB drive and everything is gone.**
+Don't reformat. The badge only understands its own FAT12 layout; if boot finds anything else (exFAT, NTFS, odd sector sizes) it silently re-formats the whole partition — wiping every file. To clear files, delete them normally instead. If it already happened: copy your `.PCX` / `.ICS` / `.CFG` files back on and reboot.
+
+**The charge bolt disappeared while USB is still plugged in.**
+Charging is **complete** — the bolt returns by itself if the cell drains. Also, the battery icon can lag up to a minute behind reality; it is only re-sampled every 60 seconds.
 
 ## Display (e-paper)
 
@@ -35,6 +47,20 @@ Your `LUT.CFG` is a fast waveform that skips red. Delete `LUT.CFG` from the badg
 **Blinking white LED / won't finish booting after dropping a `LUT.CFG`.**
 A bad or wrong-panel `LUT.CFG` is rejected automatically, but if the screen is unreadable, **hold *Fire* while booting** to force the safe built-in waveform, then delete or fix the file.
 
+**The badge boots fine but ignores my `LUT.CFG`.**
+Rejection is silent. Common causes: wrong `variant` letter for your panel, the wrong key copied from the calibration tool (it wants the flat `band_lut` hex field, not `stage_luts`), a file over ~2.8 KB (trim comments and unneeded band overrides), or bad hex length (each LUT value must be exactly 214 hex characters). Holding *Fire* at boot also forces the built-in waveform for that boot. Details in the firmware's [`LUT.md`](https://codeberg.org/Ranzbak/bornhack-firmware-2026/src/branch/main/LUT.md).
+
+## Mesh / Bluetooth
+
+**The MeshCore app says "connected" but nothing works — can't set the clock, no contacts, messages won't send.**
+Stale pairing. The phone forgot the bond (you removed it in Bluetooth settings, or switched phones) but the badge still has it, so every command is rejected as unauthenticated. Fix: **Main → Settings → Bluetooth → Clear pairings** (wipes all bonds and reboots the badge), then pair fresh. The badge keeps at most **4** bonds — pairing a fifth phone silently doesn't stick.
+
+**The Channel screen shows "BLE client connected" and the buttons are dead.**
+By design: while the phone app is connected the on-badge channel browser locks (only Left / Right / Cancel work). Close or disconnect the app and the screen unlocks immediately.
+
+**My PMs and the peers I'd heard are gone after a reboot.**
+The PM inbox and the recently-heard list live in RAM only. **Saved contacts persist** — when you meet someone you want to message later, open their entry and save them before powering off.
+
 ## NFC
 
 **My vanity URL / vCard doesn't stick.**
@@ -42,6 +68,20 @@ Write it with an NFC-writer app as a normal **URL/URI**, **vCard** or **Wi-Fi** 
 
 **A token I received disappeared / a URL I tapped reverted.**
 A `token:` write is intentionally transient — it lands on the **Tokens** screen (kept until reboot) and the broadcast reverts to your own profile after about 10 seconds. A pushed token can't overwrite your profile.
+
+**A station tap did nothing — no toast, pet unaffected.**
+Station commands only apply while you have an **active game**: pick a pet first (the egg countdown already counts), or start a new egg if your pet has left. Also: station commands come through the *signed* BadgeCtl reader — writing the phrase (e.g. `more food`) as a plain text record with a generic NFC app doesn't feed your pet; it just becomes your broadcast profile, and your badge now proudly hands out "more food" to every phone that taps it. Write a new URL / vCard to fix that.
+
+## Game / BornPets
+
+**The pet area shows "No sprites on flash".**
+The boot scan found zero `.PCX` files — typical after a factory reset, a drive reformat, or a fresh flash without the asset set. Copy the sprite `.PCX` files back onto the `CYBR<hex>` drive and reboot.
+
+**A sprite I made shows wrong colours / doesn't show at all.**
+The badge needs a very specific PCX flavour: 2 bits-per-pixel, single plane, RLE, with the fixed palette order **0 = black, 1 = red, 2 = white, 3 = transparent** (the file's own palette is ignored). A normal 256-colour or 24-bit export is silently skipped. The [Pet Maker](https://scene.rs/pets/) and the firmware's asset tool get all of this right.
+
+**`BORNPETS.CFG` / a mode change seems to have no effect.**
+Both apply at **boot only** — eject the drive properly (so the file is flushed) and power-cycle. No `*` after the pet name = no override was applied. See [Games](../games/#custom-balance-bornpetscfg).
 
 ## Where to file bugs
 

--- a/content/en/docs/Badges/Bornhack 2026/faq/_index.md
+++ b/content/en/docs/Badges/Bornhack 2026/faq/_index.md
@@ -1,0 +1,50 @@
+---
+title: "FAQ & troubleshooting"
+linkTitle: "FAQ"
+nodateline: true
+weight: 8
+---
+
+Quick answers to the things people most often hit with the Cyber Ægg. If none of these help, file a bug (see the bottom of the page).
+
+## General
+
+**The badge won't wake / the display stays blank.**
+Plug in USB-C. If the LED never blinks, hold **Execute** while plugging in and re-flash the firmware with `dfu-util` — see [Getting started → Firmware update](../getting-started/#firmware-update).
+
+**The clock keeps resetting on every reboot.**
+Expected — there is no battery-backed RTC. Pair over Bluetooth with the MeshCore app once per boot, or wait until you are near a synced mesh repeater that advertises the time. See [Getting started → Set the time](../getting-started/#set-the-time).
+
+**Bluetooth isn't visible / I can't pair.**
+Bluetooth is disabled whenever USB is connected. **Unplug the badge** and try again.
+
+**My alarm never fired.**
+The clock hasn't been set yet this boot — alarms only fire once the time is known. Set the time first.
+
+**No mesh peers show up.**
+Walk around — LoRa range varies with terrain and antenna orientation. Also check your LoRa preset under **Main → Settings → LoRa Radio**; it must match the rest of the local mesh. See [Mesh](../mesh/).
+
+## Display (e-paper)
+
+**Red only shows up sometimes — e.g. after switching screens.**
+Working as designed. Staying on one screen uses fast black/white refreshes that don't repaint the red plane; red repaints on a **full refresh** (a screen switch, or periodically). It isn't disabled — it just refreshes less often than black/white.
+
+**No red at all / washed-out screen after adding a custom LUT.**
+Your `LUT.CFG` is a fast waveform that skips red. Delete `LUT.CFG` from the badge's USB drive, or **hold *Fire* (joystick press) while booting** to force the built-in tri-colour waveform for that boot. See [Hardware → Display](../hardware/#display).
+
+**Blinking white LED / won't finish booting after dropping a `LUT.CFG`.**
+A bad or wrong-panel `LUT.CFG` is rejected automatically, but if the screen is unreadable, **hold *Fire* while booting** to force the safe built-in waveform, then delete or fix the file.
+
+## NFC
+
+**My vanity URL / vCard doesn't stick.**
+Write it with an NFC-writer app as a normal **URL/URI**, **vCard** or **Wi-Fi** record — anything you write (except a `token:`) becomes your broadcast profile and persists across reboots. See [NFC & tokens → Set your own broadcast data](../nfc/#set-your-own-broadcast-data).
+
+**A token I received disappeared / a URL I tapped reverted.**
+A `token:` write is intentionally transient — it lands on the **Tokens** screen (kept until reboot) and the broadcast reverts to your own profile after about 10 seconds. A pushed token can't overwrite your profile.
+
+## Where to file bugs
+
+Found something broken? Open an issue on the firmware repository:
+
+<https://codeberg.org/Ranzbak/bornhack-firmware-2026/issues>

--- a/content/en/docs/Badges/Bornhack 2026/games/_index.md
+++ b/content/en/docs/Badges/Bornhack 2026/games/_index.md
@@ -119,3 +119,9 @@ DRAINED_INTERVAL=180
 ```
 
 Eject the drive and reboot. When a config is active a small `*` appears after the pet's name. Delete the file and reboot to return to a preset. The Pet Maker can generate this file for you, and the firmware's [`USER_GAMES.md`](https://codeberg.org/Ranzbak/bornhack-firmware-2026/src/branch/main/USER_GAMES.md) documents every supported key and its range.
+
+A few gotchas:
+
+* **Edits apply at boot only.** Eject the drive properly (so the write is flushed), then power-cycle. No `*` after the pet name = no override was applied.
+* **The parser is silent.** Unknown keys are skipped, and a value that isn't a plain whole number (no units, decimals or minus sign) drops the whole line without any on-screen error.
+* **The documented "reasonable range" is advice, not a limit.** Values are only clamped to the raw integer type — `HUNGER_RATE=1000` really does make hunger fill ~300× faster, and your pet will be starving before you've unplugged the cable. If a wild value wrecked your pet, delete the file and reboot to fall back to the preset.

--- a/content/en/docs/Badges/Bornhack 2026/getting-started/_index.md
+++ b/content/en/docs/Badges/Bornhack 2026/getting-started/_index.md
@@ -79,8 +79,11 @@ When plugged in over USB-C the badge appears as a small drive named **`CYBR<4 he
 | `030000.PCX` … `030009.PCX` | Sponsor slides shown on the splash carousel |
 | `<6 hex>.PCX` | Game sprites |
 | `BORNPETS.CFG` | Override the BornPets game balance |
+| `LUT.CFG` | Custom e-paper waveform (advanced — calibrated display LUT) |
 
 Reboot the badge after copying files (re-plug USB) for the changes to take effect.
+
+`LUT.CFG` is an advanced tweak: it overrides the panel's built-in display waveform with a calibrated one (e.g. faster refresh). If a custom LUT ever renders badly, **hold *Fire* (joystick press) while booting** to force the safe built-in waveform for that boot, then delete or fix the file. A malformed or wrong-panel `LUT.CFG` is rejected automatically.
 
 ## Firmware update
 

--- a/content/en/docs/Badges/Bornhack 2026/getting-started/_index.md
+++ b/content/en/docs/Badges/Bornhack 2026/getting-started/_index.md
@@ -69,6 +69,8 @@ Set your timezone once under **Main → Settings → Timezone** — that setting
 
 Plug any USB-C cable into the badge to charge it. Charge state is shown on the on-screen battery icon (there is no dedicated charge LED). Remember that Bluetooth is off while USB is connected, so unplug the badge when you want to pair.
 
+Two things that look like faults but aren't: the charge bolt disappearing while USB is still plugged means charging is **complete** (it returns by itself if the cell drains), and the battery icon can lag up to a minute behind reality — it is only re-sampled every 60 seconds.
+
 ## USB drag-and-drop
 
 When plugged in over USB-C the badge appears as a small drive named **`CYBR<4 hex>`**. You can drop these files into its root:
@@ -78,6 +80,7 @@ When plugged in over USB-C the badge appears as a small drive named **`CYBR<4 he
 | `ALARMS.ICS` | iCalendar file — imports alarms and calendar events |
 | `030000.PCX` … `030009.PCX` | Sponsor slides shown on the splash carousel |
 | `<6 hex>.PCX` | Game sprites |
+| `PETS.CFG` | Add / rename pets (with their sprite PCX files) — see [Games](../games/#custom-pet-roster-petscfg) |
 | `BORNPETS.CFG` | Override the BornPets game balance |
 | `LUT.CFG` | Custom e-paper waveform (advanced — calibrated display LUT) |
 

--- a/content/en/docs/Badges/Bornhack 2026/hardware/_index.md
+++ b/content/en/docs/Badges/Bornhack 2026/hardware/_index.md
@@ -31,6 +31,8 @@ At the time of writing the design is still at prototype stage. Some of the RF ci
 
 The badge uses a 1.54 inch tri-colour (black / red / white) e-paper display with a resolution of **152 × 152** pixels, driven by an SSD1675 / SSD1675B controller. E-paper keeps the badge readable in bright camp sunlight and draws no power to hold an image, which is a big help for the week-long battery goal.
 
+By default the panel is driven with the waveform LUT stored in its own OTP. Advanced users can override this with a calibrated waveform (for example a faster refresh) by dropping a `LUT.CFG` file on the USB drive — see the firmware's [`LUT.md`](https://codeberg.org/Ranzbak/bornhack-firmware-2026/src/branch/main/LUT.md). Holding *Fire* while booting always forces the safe built-in waveform.
+
 ## Manual input
 
 Because the Cyber Ægg is inspired by the 90's Tamagotchi egg-shaped toy, the buttons carry the same names:

--- a/content/en/docs/Badges/Bornhack 2026/nfc/_index.md
+++ b/content/en/docs/Badges/Bornhack 2026/nfc/_index.md
@@ -26,6 +26,8 @@ A phone running the **BadgeCtl** companion app, loaded with the matching event k
 
 A short toast on the badge confirms what happened. Each command has a **5-minute cooldown** — tapping twice in quick succession does nothing the second time.
 
+Station commands need an **active game**: pick a pet first (the egg countdown already counts). If your pet has left, start a new egg — a tap with no active pet is silently ignored.
+
 ## Tokens
 
 Tokens you collect from station taps (and from other badges) land on the **Tokens** carousel screen. The badge collects **many** tokens and keeps them until the next reboot, so it is a running record of the stations and badges you tapped during the camp.
@@ -40,7 +42,9 @@ The default `badge.team` URL is not fixed — you can make the badge hand out **
 * **vCard** — write a Contact / vCard record; phones tapping you then get your contact card.
 * **Wi-Fi**, or any other record — served verbatim.
 
-The rule is simple: **anything you write sticks and survives a reboot — except a `token:`, which lands on your Tokens screen instead.** Keep it short; records are capped at ~127 bytes (fine for a URL or a compact vCard).
+The rule is simple: **anything you write sticks and survives a reboot — except a `token:`, which lands on your Tokens screen instead.** Keep it short; records are capped at ~127 bytes (fine for a URL or a compact vCard). Long URLs sent via the `set:` text form are additionally clamped to ~118 characters after the scheme — for anything longer, write a plain URI record instead, or use a link shortener.
+
+There is no NFC "erase" back to the factory default: an empty write (or a writer app's "format tag") doesn't restore the `badge.team` URL — it just leaves your current profile in place (or stores the empty record). To change what you broadcast, simply write the new record over it.
 
 Setting this is **unauthenticated** — anyone who can physically tap your badge with a writer app can change it. It is your badge in your pocket; treat physical access accordingly.
 

--- a/content/en/docs/Badges/Bornhack 2026/nfc/_index.md
+++ b/content/en/docs/Badges/Bornhack 2026/nfc/_index.md
@@ -9,9 +9,9 @@ The back of the badge has an NFC antenna. Tap a phone or a station reader agains
 
 ## Two things happen on a tap
 
-### A phone reads the URL
+### A phone reads your broadcast profile
 
-Any standard NFC reader (the built-in Android reader, iOS) sees a `https://badge.team` URL containing your badge ID. Tapping with the OS reader simply opens that page in a browser. Harmless.
+Any standard NFC reader (the built-in Android reader, iOS) sees whatever you have set as your **broadcast profile** — by default a `https://badge.team` URL, but you can replace it with your own vanity URL, a vCard and more (see [Set your own broadcast data](#set-your-own-broadcast-data)). Tapping with the OS reader simply reads it. Harmless.
 
 ### BadgeCtl runs a station command
 
@@ -28,7 +28,21 @@ A short toast on the badge confirms what happened. Each command has a **5-minute
 
 ## Tokens
 
-Tokens you collect from station taps (and from other badges) show up on the **Tokens** carousel screen — a running record of the stations you've visited during the camp.
+Tokens you collect from station taps (and from other badges) land on the **Tokens** carousel screen. The badge collects **many** tokens and keeps them until the next reboot, so it is a running record of the stations and badges you tapped during the camp.
+
+When someone pushes a `token:` onto your badge it shows for about **10 seconds**, then the badge reverts to broadcasting your own profile — a pushed token can't overwrite it.
+
+## Set your own broadcast data
+
+The default `badge.team` URL is not fixed — you can make the badge hand out **anything you like**. Use any NFC-writer app on your phone (e.g. *NFC Tools*) and write to the back of the badge:
+
+* **Vanity URL** — write a URL / URI record (e.g. `annejan.com`). A **Text** record `set:https://your.link` also works for writer apps that only emit text.
+* **vCard** — write a Contact / vCard record; phones tapping you then get your contact card.
+* **Wi-Fi**, or any other record — served verbatim.
+
+The rule is simple: **anything you write sticks and survives a reboot — except a `token:`, which lands on your Tokens screen instead.** Keep it short; records are capped at ~127 bytes (fine for a URL or a compact vCard).
+
+Setting this is **unauthenticated** — anyone who can physically tap your badge with a writer app can change it. It is your badge in your pocket; treat physical access accordingly.
 
 ## What the reader side needs
 

--- a/content/en/docs/Badges/Bornhack 2026/quick-reference/_index.md
+++ b/content/en/docs/Badges/Bornhack 2026/quick-reference/_index.md
@@ -55,6 +55,7 @@ Hold these while connecting USB / resetting:
 | Hold | Result |
 | ---- | ------ |
 | **Execute** | USB firmware update (DFU mode) |
+| **Fire** (joystick press) | Force safe e-paper waveform (ignore a bad `LUT.CFG` for that boot) |
 | **Execute + Cancel + Fire** | Factory reset (~40 s — wipes data and settings) |
 
 If the app slot is blank the badge enters DFU on its own.
@@ -69,6 +70,7 @@ Plug in USB-C — the badge mounts as the **`CYBR<4 hex>`** drive.
 | `030000.PCX` … `030009.PCX` | Sponsor slides |
 | `<6 hex>.PCX` | Game sprite asset |
 | `BORNPETS.CFG` | Custom pet balance (`KEY=VALUE`) |
+| `LUT.CFG` | Custom e-paper waveform (advanced) |
 
 Reboot the badge after dropping files.
 

--- a/content/en/docs/Badges/Bornhack 2026/quick-reference/_index.md
+++ b/content/en/docs/Badges/Bornhack 2026/quick-reference/_index.md
@@ -69,6 +69,7 @@ Plug in USB-C — the badge mounts as the **`CYBR<4 hex>`** drive.
 | `ALARMS.ICS` | Imports alarms + calendar events |
 | `030000.PCX` … `030009.PCX` | Sponsor slides |
 | `<6 hex>.PCX` | Game sprite asset |
+| `PETS.CFG` | Add / rename pets (with sprite PCX files) |
 | `BORNPETS.CFG` | Custom pet balance (`KEY=VALUE`) |
 | `LUT.CFG` | Custom e-paper waveform (advanced) |
 


### PR DESCRIPTION
Syncs the Bornhack 2026 (Cyber Ægg) docs with new user-facing firmware features and documentation landed since the pages were written (Ranzbak/bornhack-firmware-2026, up to #103).

## Changes
- **NFC & tokens** — broadcast profile is now **settable** (vanity URL, vCard, Wi-Fi, …), not a fixed `badge.team` URL. Added "Set your own broadcast data", token collection semantics (kept until reboot, transient `token:` push), station commands need an active pet, `set:` URL clamp, no NFC erase back to factory default.
- **Getting started / Quick reference** — added `PETS.CFG` and `LUT.CFG` to the USB drag-and-drop tables, *Fire*-while-booting waveform recovery, charging quirks (bolt-gone = complete, battery icon lags ≤ 60 s).
- **Hardware** — `LUT.CFG` custom-waveform override note on the Display section.
- **Clock & alarm** — trusted-source rule for on-air time, and a full "Import limits & quirks" section for `ALARMS.ICS` (16 KiB cap + `strip_ics.py`, 31 events, no RRULE, no all-day, ASCII-only, UTC+2-at-import, fired one-shots hidden until reboot).
- **Games** — `BORNPETS.CFG` gotchas (boot-only, silent parser, ranges are advice not clamps).
- **New FAQ & troubleshooting page** — ports both rounds of the firmware troubleshooting docs: general (ship-screen halt, battery-critical boot, drive-reformat warning), e-paper (red plane, custom-LUT recovery + silent-reject checklist), Mesh/BLE (stale bonds & Clear pairings, 4-bond cap, locked Channel screen, RAM-only PMs), NFC and Game/BornPets sections, plus the bug-report link.

Docs-only; content is covered by the existing REUSE glob (`reuse lint` passes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)