### PR TITLE
Link the ssd1675-calibration LUT tool from the docs

### DIFF
--- a/content/en/docs/Badges/Bornhack 2026/faq/_index.md
+++ b/content/en/docs/Badges/Bornhack 2026/faq/_index.md
@@ -57,7 +57,7 @@ Your `LUT.CFG` is a fast waveform that skips red. Delete `LUT.CFG` from the badg
 A bad or wrong-panel `LUT.CFG` is rejected automatically, but if the screen is unreadable, **hold *Fire* while booting** to force the safe built-in waveform, then delete or fix the file.
 
 **The badge boots fine but ignores my `LUT.CFG`.**
-Rejection is silent. Common causes: wrong `variant` letter for your panel, the wrong key copied from the calibration tool (it wants the flat `band_lut` hex field, not `stage_luts`), a file over ~2.8 KB (trim comments and unneeded band overrides), or bad hex length (each LUT value must be exactly 214 hex characters). Holding *Fire* at boot also forces the built-in waveform for that boot. Details in the firmware's [`LUT.md`](https://codeberg.org/Ranzbak/bornhack-firmware-2026/src/branch/main/LUT.md).
+Rejection is silent. Common causes: wrong `variant` letter for your panel, the wrong key copied from the [ssd1675-calibration](https://codeberg.org/Ranzbak/ssd1675-calibration) tool (it wants the flat `band_lut` hex field, not `stage_luts`), a file over ~2.8 KB (trim comments and unneeded band overrides), or bad hex length (each LUT value must be exactly 214 hex characters). Holding *Fire* at boot also forces the built-in waveform for that boot. Details in the firmware's [`LUT.md`](https://codeberg.org/Ranzbak/bornhack-firmware-2026/src/branch/main/LUT.md).
 
 ## Mesh / Bluetooth
 

--- a/content/en/docs/Badges/Bornhack 2026/hardware/_index.md
+++ b/content/en/docs/Badges/Bornhack 2026/hardware/_index.md
@@ -34,7 +34,7 @@ There is a QWIIC like I2C expansion connector on the board. Be aware that we mad
 
 The badge uses a 1.54 inch tri-colour (black / red / white) e-paper display with a resolution of **152 × 152** pixels, driven by an SSD1675 / SSD1675B controller. E-paper keeps the badge readable in bright camp sunlight and draws no power to hold an image, which is a big help for the week-long battery goal.
 
-By default the panel is driven with the waveform LUT stored in its own OTP. Advanced users can override this with a calibrated waveform (for example a faster refresh) by dropping a `LUT.CFG` file on the USB drive — see the firmware's [`LUT.md`](https://codeberg.org/Ranzbak/bornhack-firmware-2026/src/branch/main/LUT.md). Holding *Fire* while booting always forces the safe built-in waveform.
+By default the panel is driven with the waveform LUT stored in its own OTP. Advanced users can override this with a calibrated waveform (for example a faster refresh) by dropping a `LUT.CFG` file on the USB drive — see the firmware's [`LUT.md`](https://codeberg.org/Ranzbak/bornhack-firmware-2026/src/branch/main/LUT.md). You can generate one with the [ssd1675-calibration](https://codeberg.org/Ranzbak/ssd1675-calibration) tool. Holding *Fire* while booting always forces the safe built-in waveform.
 
 ## Manual input
 


### PR DESCRIPTION
The Hardware and FAQ pages describe generating a custom `LUT.CFG` waveform but never linked the tool that produces it.

Adds a link to [Ranzbak/ssd1675-calibration](https://codeberg.org/Ranzbak/ssd1675-calibration) on:
- **Hardware → Display** (next to the `LUT.md` link)
- **FAQ** (the "boots fine but ignores my `LUT.CFG`" entry)

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)