### PR TITLE
Sync Bornhack 2026 docs with firmware (Jul 14–16 update)

### DIFF
--- a/content/en/docs/Badges/Bornhack 2026/faq/_index.md
+++ b/content/en/docs/Badges/Bornhack 2026/faq/_index.md
@@ -57,7 +57,7 @@ Your `LUT.CFG` is a fast waveform that skips red. Delete `LUT.CFG` from the badg
 A bad or wrong-panel `LUT.CFG` is rejected automatically, but if the screen is unreadable, **hold *Fire* while booting** to force the safe built-in waveform, then delete or fix the file.
 
 **The badge boots fine but ignores my `LUT.CFG`.**
-Rejection is silent. Common causes: wrong `variant` letter for your panel, the wrong key copied from the [ssd1675-calibration](https://codeberg.org/Ranzbak/ssd1675-calibration) tool (it wants the flat `band_lut` hex field, not `stage_luts`), a file over ~2.8 KB (trim comments and unneeded band overrides), or bad hex length (each LUT value must be exactly 214 hex characters). Holding *Fire* at boot also forces the built-in waveform for that boot. Details in the firmware's [`LUT.md`](https://codeberg.org/Ranzbak/bornhack-firmware-2026/src/branch/main/LUT.md).
+Rejection is silent. Common causes: wrong `variant` letter for your panel, the wrong key copied from the [ssd1675-calibration](https://codeberg.org/Ranzbak/ssd1675-calibration) tool (it wants the flat `band_lut` hex field, not `stage_luts`), or bad hex length (each LUT value must be exactly 214 hex characters). File size is *not* a limit — the file is streamed off flash, so a full 16-band export (~3.7 KB, comments and all) loads fine. Holding *Fire* at boot also forces the built-in waveform for that boot. Details in the firmware's [`LUT.md`](https://codeberg.org/Ranzbak/bornhack-firmware-2026/src/branch/main/LUT.md).
 
 ## Mesh / Bluetooth
 
@@ -87,7 +87,7 @@ Station commands only apply while you have an **active game**: pick a pet first 
 The boot scan found zero `.PCX` files — typical after a factory reset, a drive reformat, or a fresh flash without the asset set. Copy the sprite `.PCX` files back onto the `CYBR<hex>` drive and reboot.
 
 **A sprite I made shows wrong colours / doesn't show at all.**
-The badge needs a very specific PCX flavour: 2 bits-per-pixel, single plane, RLE, with the fixed palette order **0 = black, 1 = red, 2 = white, 3 = transparent** (the file's own palette is ignored). A normal 256-colour or 24-bit export is silently skipped. The [Pet Maker](https://scene.rs/pets/) and the firmware's asset tool get all of this right.
+The badge needs a very specific PCX flavour: 2 bits-per-pixel, single plane, RLE, with the fixed palette order **0 = black, 1 = red, 2 = white, 3 = transparent** (the file's own palette is ignored). A normal 256-colour or 24-bit export is silently skipped. The [Pet Maker](https://scene.rs/pets/) and the firmware's asset tool get all of this right. If you hand-edited a sprite in GIMP, re-pack it with the firmware's [`scripts/fix_badge_pcx.py`](https://codeberg.org/Ranzbak/bornhack-firmware-2026/src/branch/main/scripts/fix_badge_pcx.py) (or check it first with `check_badge_pcx.py`) — see [Games → Hand-editing sprites](../games/#hand-editing-sprites-gimp-etc).
 
 **`BORNPETS.CFG` / a mode change seems to have no effect.**
 Both apply at **boot only** — eject the drive properly (so the file is flushed) and power-cycle. No `*` after the pet name = no override was applied. See [Games](../games/#custom-balance-bornpetscfg).

--- a/content/en/docs/Badges/Bornhack 2026/games/_index.md
+++ b/content/en/docs/Badges/Bornhack 2026/games/_index.md
@@ -51,6 +51,10 @@ Two difficulty presets, picked via **Main → Bornagotchi → Mode**:
 
 The setting persists in flash. A `*` next to the mode name means the change is queued — **reboot the badge** for it to take effect.
 
+### Turning the pet off
+
+Not a pet person? **Main → Bornagotchi → Disable Game** hides the whole Game screen from the carousel. The toggle persists across reboots (the label flips to *Enable Game* once off) and, while disabled, an NFC station tap can no longer jump you into the pet. Flip it back to *Enable Game* to bring the pet screen back.
+
 ## Mini-games
 
 Open the bottom-row **Play** menu in BornPets and pick a game. Each win reduces the *drained* stat without raising hunger, so they are free entertainment. **Cancel** always exits a mini-game.
@@ -84,6 +88,14 @@ With it you can:
 ### Installing a custom pet
 
 The badge exposes a USB drive when plugged in over USB-C (see [Getting started](../getting-started/#usb-drag-and-drop)). Unzip the export from the Pet Maker and copy the sprite files — plus `PETS.CFG`, and `BORNPETS.CFG` if you made one — into the root of the `CYBR<4 hex>` drive, then reboot the badge.
+
+### Hand-editing sprites (GIMP etc.)
+
+The badge only accepts a very specific PCX flavour (2 bits-per-pixel, single plane, RLE). Editors like GIMP happily export 16- or 256-colour PCX instead, which the badge silently skips. The firmware's [`scripts/`](https://codeberg.org/Ranzbak/bornhack-firmware-2026/src/branch/main/scripts) folder has helpers for exactly this:
+
+* [`fix_badge_pcx.py`](https://codeberg.org/Ranzbak/bornhack-firmware-2026/src/branch/main/scripts/fix_badge_pcx.py) — re-packs a wrong-depth PCX (e.g. a 4bpp/8bpp GIMP export) back to the badge's 2bpp format, preserving dimensions.
+* [`png_to_badge_pcx.py`](https://codeberg.org/Ranzbak/bornhack-firmware-2026/src/branch/main/scripts/png_to_badge_pcx.py) — converts a PNG straight to a 152×152 badge PCX.
+* [`check_badge_pcx.py`](https://codeberg.org/Ranzbak/bornhack-firmware-2026/src/branch/main/scripts/check_badge_pcx.py) — validates a file before you copy it over, so you catch a bad export on your computer instead of on the badge.
 
 ## Custom pet roster: `PETS.CFG`
 

--- a/content/en/docs/Badges/Bornhack 2026/getting-started/_index.md
+++ b/content/en/docs/Badges/Bornhack 2026/getting-started/_index.md
@@ -11,6 +11,8 @@ Welcome to the BornHack 2026 **Cyber Ægg** badge. This guide takes you from "un
 
 A fresh badge runs a built-in factory self-test on the very first boot. You will see a `FACTORY TEST` screen with a small PASS/FAIL grid, followed by `ALL PASS`. After that the badge goes straight to the application on every boot; the self-test never runs again unless the firmware is wiped.
 
+The very first boot then plays a short one-time sponsor slideshow (the event logos, then the badge-sponsor logos, a couple of seconds each) before dropping you on the Main screen. It only runs once per badge — you can replay it any time from **Main → Badge sponsors**.
+
 The LED sequence at every boot is:
 
 1. Pulsing **orange** — hardware initialisation
@@ -37,7 +39,7 @@ The interface is a carousel — **Left** / **Right** cycles through the top-leve
 | Screen | What it is |
 | ------ | ---------- |
 | **Game** | BornPets — virtual pet, mini-games and hatchery |
-| **Main** | Root menu: Bornagotchi · Settings · About |
+| **Main** | Root menu: Bornagotchi · Settings · About · Badge sponsors |
 | **PMs** | Private mesh messages inbox |
 | **Channel** | Group / room mesh chat |
 | **Adverts** | Recently heard mesh adverts |

--- a/content/en/docs/Badges/Bornhack 2026/hardware/_index.md
+++ b/content/en/docs/Badges/Bornhack 2026/hardware/_index.md
@@ -64,6 +64,18 @@ The nRF52840 includes an NFC PHY, used here to drive a resonant circuit consisti
 
 There is a QWIIC like I2C expansion connector on the board. Be aware that we made a small design mistake: the 3.3v and GND signals have been swapped around. Make sure to use a modified cable before connecting any QWIIC peripherals.
 
+{{% alert title="Fix the cable — cross the two power wires" color="warning" %}}
+A standard QWIIC / JST-SH 4-pin cable carries **GND · 3V3 · SDA · SCL**. Because the badge swaps 3.3 V and GND, plugging in a stock cable feeds **reversed power** into your peripheral — don't do it.
+
+To make a corrected cable, swap the two power wires on **one end only** (leave the other end standard so it still mates with the peripheral):
+
+1. On the badge end of the cable, lift the small locking tab on the JST-SH housing and gently pull the **GND** and **3V3** contacts out (a fine pick or tweezers works).
+2. Swap them: the wire that was in the GND slot goes into the 3V3 slot and vice-versa. The two data wires (SDA, SCL) stay put.
+3. Push both contacts back until they click, and confirm nothing is loose.
+
+The data lines are unaffected, so only the two power contacts move. Mark the fixed cable so you don't mix it up with a standard one. If you'd rather not re-pin, cut and re-solder the red (3V3) and black (GND) wires crossed, or just keep a dedicated "badge only" cable.
+{{% /alert %}}
+
 The badge carries a connector that should have been [QWIIC](https://www.sparkfun.com/qwiic) compatible. QWIIC is a standardised I²C connector used by a large range of SparkFun and third-party breakout boards. Two 10 kΩ pull-up resistors are fitted on the board, and the nRF52840's internal pull-ups can be enabled as well when the bus capacitance is high.
 
 The firmware can also drive an optional **Nicolai-Electronics I²C keyboard** on this bus for typing names and mesh messages — plug it in (with the corrected cable) and text entry uses the physical keys, with Shift / Alt one-shot toggles and an alt-symbol layer matching the silkscreen. Without a keyboard the badge falls back to the on-screen joystick picker automatically.

--- a/content/en/docs/Badges/Bornhack 2026/hardware/_index.md
+++ b/content/en/docs/Badges/Bornhack 2026/hardware/_index.md
@@ -66,6 +66,8 @@ There is a QWIIC like I2C expansion connector on the board. Be aware that we mad
 
 The badge carries a connector that should have been [QWIIC](https://www.sparkfun.com/qwiic) compatible. QWIIC is a standardised I²C connector used by a large range of SparkFun and third-party breakout boards. Two 10 kΩ pull-up resistors are fitted on the board, and the nRF52840's internal pull-ups can be enabled as well when the bus capacitance is high.
 
+The firmware can also drive an optional **Nicolai-Electronics I²C keyboard** on this bus for typing names and mesh messages — plug it in (with the corrected cable) and text entry uses the physical keys, with Shift / Alt one-shot toggles and an alt-symbol layer matching the silkscreen. Without a keyboard the badge falls back to the on-screen joystick picker automatically.
+
 ## Power
 
 The badge is powered by a LiPo battery and charged over USB-C. Bluetooth is disabled while USB is connected to keep the charging path simple, so unplug the badge when you want to pair with the MeshCore app.

--- a/content/en/docs/Badges/Bornhack 2026/nfc/_index.md
+++ b/content/en/docs/Badges/Bornhack 2026/nfc/_index.md
@@ -11,7 +11,7 @@ The back of the badge has an NFC antenna. Tap a phone or a station reader agains
 
 ### A phone reads your broadcast profile
 
-Any standard NFC reader (the built-in Android reader, iOS) sees whatever you have set as your **broadcast profile** — by default a `https://badge.team` URL, but you can replace it with your own vanity URL, a vCard and more (see [Set your own broadcast data](#set-your-own-broadcast-data)). Tapping with the OS reader simply reads it. Harmless.
+Any standard NFC reader (the built-in Android reader, iOS) sees whatever you have set as your **broadcast profile** — by default the badge's own docs page `https://badge.team/docs/badges/bornhack-2026/`, but you can replace it with your own vanity URL, a vCard and more (see [Set your own broadcast data](#set-your-own-broadcast-data)). Tapping with the OS reader simply reads it. Harmless.
 
 ### BadgeCtl runs a station command
 
@@ -36,7 +36,7 @@ When someone pushes a `token:` onto your badge it shows for about **10 seconds**
 
 ## Set your own broadcast data
 
-The default `badge.team` URL is not fixed — you can make the badge hand out **anything you like**. Use any NFC-writer app on your phone (e.g. *NFC Tools*) and write to the back of the badge:
+The default docs-page URL is not fixed — you can make the badge hand out **anything you like**. Use any NFC-writer app on your phone (e.g. *NFC Tools*) and write to the back of the badge:
 
 * **Vanity URL** — write a URL / URI record (e.g. `annejan.com`). A **Text** record `set:https://your.link` also works for writer apps that only emit text.
 * **vCard** — write a Contact / vCard record; phones tapping you then get your contact card.
@@ -44,7 +44,7 @@ The default `badge.team` URL is not fixed — you can make the badge hand out **
 
 The rule is simple: **anything you write sticks and survives a reboot — except a `token:`, which lands on your Tokens screen instead.** Keep it short; records are capped at ~127 bytes (fine for a URL or a compact vCard). Long URLs sent via the `set:` text form are additionally clamped to ~118 characters after the scheme — for anything longer, write a plain URI record instead, or use a link shortener.
 
-There is no NFC "erase" back to the factory default: an empty write (or a writer app's "format tag") doesn't restore the `badge.team` URL — it just leaves your current profile in place (or stores the empty record). To change what you broadcast, simply write the new record over it.
+There is no NFC "erase" back to the factory default: an empty write (or a writer app's "format tag") doesn't restore the built-in docs URL — it just leaves your current profile in place (or stores the empty record). To change what you broadcast, simply write the new record over it.
 
 Setting this is **unauthenticated** — anyone who can physically tap your badge with a writer app can change it. It is your badge in your pocket; treat physical access accordingly.
 


### PR DESCRIPTION
Syncs the Cyber Ægg badge docs to the latest user-facing changes in [Ranzbak/bornhack-firmware-2026](https://codeberg.org/Ranzbak/bornhack-firmware-2026) (14–16 Jul).

## Changes
- **LUT.CFG size limit gone** — the file is now streamed off flash, so the old "~2.8 KB" reject reason is removed from the FAQ; a full 16-band export (~3.7 KB) loads fine.
- **Default NFC broadcast profile** now points at the badge's own docs page (`https://badge.team/docs/badges/bornhack-2026/`) instead of `badge.team`.
- **I²C keyboard** — document the optional Nicolai-Electronics keyboard on the expansion connector for text entry (falls back to the joystick picker).
- **Disable Game** — document the new persisted toggle (hides the pet screen, blocks the NFC pet-jump).
- **Sprite helper scripts** — link `fix_badge_pcx.py` / `png_to_badge_pcx.py` / `check_badge_pcx.py` from the Games page and the sprite-colours FAQ, for hand-edited (GIMP) sprites.
- **Sponsors** — note the first-boot one-time slideshow and the new "Badge sponsors" root-menu entry.
- **QWIIC cable fix** — step-by-step instructions to cross the swapped 3.3 V / GND power wires on the expansion cable.

`reuse lint` stays green (361/361).

🤖 Generated with [Claude Code](https://claude.com/claude-code)