### PR TITLE
Move the flasher page under the Bornhack 2026 badge docs

### DIFF
--- a/content/en/docs/Badges/Bornhack 2026/_index.md
+++ b/content/en/docs/Badges/Bornhack 2026/_index.md
@@ -37,7 +37,7 @@ There is a QWIIC like I2C expansion connector on the board. Be aware that we mad
 New to the badge? Start with the [Getting started](./getting-started/) guide. Curious about the virtual pet? See [Games](./games/). Want to know what is inside? See the [Hardware](./hardware/) page.
 
 {{% alert title="Update your badge from the browser" color="info" %}}
-The [**Flash** page](/flash/) installs firmware and the badge's asset files straight from a Chromium-family browser over USB — no toolchain and no command line. It offers both the standard firmware and the Community Edition, a fork with extra BornPets mechanics.
+The [**Flash** page](./flash/) installs firmware and the badge's asset files straight from a Chromium-family browser over USB — no toolchain and no command line. It offers both the standard firmware and the Community Edition, a fork with extra BornPets mechanics.
 {{% /alert %}}
 
 ## Source code

--- a/content/en/docs/Badges/Bornhack 2026/flash/_index.md
+++ b/content/en/docs/Badges/Bornhack 2026/flash/_index.md
@@ -1,12 +1,8 @@
 ---
 title: "Flash your badge"
 linkTitle: "Flash"
-menu:
-  main:
-    weight: 25
-    pre: <i class='fas fa-bolt'></i>
 nodateline: true
-weight: 25
+weight: 9
 ---
 
 Flash firmware onto your badge straight from this page — no toolchain, no

--- a/content/en/docs/Badges/Bornhack 2026/getting-started/_index.md
+++ b/content/en/docs/Badges/Bornhack 2026/getting-started/_index.md
@@ -92,7 +92,9 @@ Reboot the badge after copying files (re-plug USB) for the changes to take effec
 
 ## Firmware update
 
-Hold **Execute** while plugging in USB to enter the bootloader (DFU) mode — the LED blinks red. You can then flash a new firmware image with [`dfu-util`](https://dfu-util.sourceforge.net/):
+The easiest route is the [Flash page](../flash/): it writes the firmware and the badge's asset files straight from a Chromium-family browser, with no toolchain to install.
+
+To do it by hand, hold **Execute** while plugging in USB to enter the bootloader (DFU) mode — the LED blinks red. You can then flash a new firmware image with [`dfu-util`](https://dfu-util.sourceforge.net/):
 
 ```
 dfu-util -d 1915:521f -D cyber-aegg.bin


### PR DESCRIPTION
Follow-up to #222. `/flash/` → `/docs/badges/bornhack-2026/flash/`

The flasher was a top-level page with its own main-menu entry, which overstated it: it flashes exactly one badge, and everything it references lives in the Bornhack 2026 section. Now it sits with the badge it serves and shows up in that section's sidebar.

- Main-menu entry dropped; the page sorts after the FAQ (weight 9).
- The landing page's callout points at the new relative location.
- Also linked from **Getting started → Firmware update** — where someone wanting to reflash actually lands, and which until now offered only the `dfu-util` route.

The static assets keep their `/flash/` URLs: `flasher.js` and `flasher.css` are served from `static/flash/`, so the page move does not touch them.

## Testing

Rebuilt from scratch on top of current `master`:

- Both links resolve to `/docs/badges/bornhack-2026/flash/` (landing page and Getting started), and the page appears in the section sidebar.
- The main menu no longer carries a Flash entry.
- `hugo --gc --minify` clean, `reuse lint` green.
- The flasher and asset tests still pass against the page at its new path (both editions, 171 and 265 files, byte-identical after inflate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)