### PR TITLE
Say that DOOM needs a WAD, and link to where you get it

### DIFF
--- a/content/en/docs/Badges/Bornhack 2026/flash/_index.md
+++ b/content/en/docs/Badges/Bornhack 2026/flash/_index.md
@@ -45,9 +45,10 @@ persists, report it.
 **The badge says "No sprites on flash".** The firmware is installed but the
 asset files are not. Do step 5 above, then power-cycle.
 
-**I flashed DOOM and step 5 disappeared.** Expected: DOOM ignores the USB drive
-entirely. Its game data goes into the badge's QSPI flash instead — see
-[DOOM](../doom/) for the WAD upload.
+**I flashed DOOM and nothing happens / it asks for game data.** Flashing DOOM is
+only half of it. DOOM ignores the USB drive entirely: its game data goes into the
+badge's QSPI flash over a serial connection, so you need to
+[upload a WAD](../doom/) before there is anything to play.
 
 **Sprites are missing or wrong after switching edition.** Each firmware image
 ships its own asset set, and the Community Edition draws a good deal more than

--- a/data/firmwares.toml
+++ b/data/firmwares.toml
@@ -77,7 +77,10 @@ appPid = "0x0001"
   # from main @ dbad849 (2026-07-21). Links at 0x10000 like the others.
   file = "/firmware/cyber-aegg/cyber-aegg-doom.bin"
   sha256 = "c470cc78b6bf70348c0cd3f0f56e5c9e729867d16c91bfd8d06f18e36d8a4161"
-  notes = "DOOM E1M1, rendered on the e-paper panel at a couple of frames per second, with the level's music on the buzzer. It replaces the badge firmware entirely — no BornPets, mesh or clock until you flash one of those back."
+  notes = "DOOM E1M1, rendered on the e-paper panel at a couple of frames per second, with the level's music on the buzzer. Flashing this is only half the job: the game data is far too big for the USB drive, so you have to upload a WAD separately before DOOM will start. It also replaces the badge firmware — no BornPets, mesh or clock until you flash one of those back, though your pet and settings survive in flash."
+  # Rendered as a link under the notes, and in place of the asset step.
+  moreUrl = "../doom/"
+  moreLabel = "How to upload the WAD →"
   # No `assets` table: DOOM ignores the FAT12 drive. Its game data lives in
   # the 2 MB QSPI flash and is uploaded separately over serial, so the asset
   # step hides itself for this image.

--- a/layouts/_shortcodes/flasher.html
+++ b/layouts/_shortcodes/flasher.html
@@ -138,6 +138,14 @@
     </p>
   </section>
 
+  <section class="flasher-step d-none" id="assets-elsewhere">
+    <h3><span class="flasher-num">5</span> Add the game data</h3>
+    <p id="assets-elsewhere-text"></p>
+    <div class="flasher-row">
+      <a id="assets-elsewhere-link" class="btn btn-primary" href="#"></a>
+    </div>
+  </section>
+
   <details class="flasher-diag">
     <summary>Diagnostics</summary>
     <div class="flasher-row">

--- a/static/flash/assets.js
+++ b/static/flash/assets.js
@@ -36,6 +36,9 @@ const el = {
   progress: $("assets-progress"),
   progLabel: $("assets-progress-label"),
   log: $("log"),
+  elsewhere: $("assets-elsewhere"),
+  elsewhereText: $("assets-elsewhere-text"),
+  elsewhereLink: $("assets-elsewhere-link"),
 };
 
 let badge = badges[0];
@@ -231,8 +234,28 @@ function syncWipeLabel() {
   el.btnCopy.classList.toggle("btn-primary", !el.chkWipe.checked);
 }
 
+function currentFirmware() {
+  return badge?.firmware?.[Number(el.fwSelect.value)] || null;
+}
+
 function refresh() {
   const assets = currentAssets();
+  const fw = currentFirmware();
+
+  // An image whose data lives in QSPI rather than on the USB drive has no
+  // asset zip. Say where that data comes from instead of just dropping the
+  // step and leaving a gap in the numbering.
+  if (!assets && fw?.wad && el.elsewhere) {
+    card.classList.add("d-none");
+    el.elsewhere.classList.remove("d-none");
+    el.elsewhereText.textContent =
+      `${fw.label} keeps its game data in the badge's QSPI flash, not on the USB drive, so there is nothing to copy here. It is uploaded over a serial connection instead — and until you do that, the badge has no game to run.`;
+    el.elsewhereLink.href = fw.moreUrl || "../doom/";
+    el.elsewhereLink.textContent = fw.moreLabel || "Upload the game data →";
+    return;
+  }
+  el.elsewhere?.classList.add("d-none");
+
   if (!assets) {
     card.classList.add("d-none");
     return;

--- a/static/flash/flasher.js
+++ b/static/flash/flasher.js
@@ -505,6 +505,16 @@ function updateFlashButton() {
 function renderFirmwareNotes() {
   const fw = selectedFirmware();
   el.fwNotes.textContent = fw?.notes || "";
+  // Some images need a follow-up step elsewhere (DOOM wants its WAD), so let
+  // the registry attach a link. Built as an element rather than injected as
+  // markup, so the notes stay plain text.
+  if (fw?.moreUrl) {
+    el.fwNotes.appendChild(document.createTextNode(" "));
+    const a = document.createElement("a");
+    a.href = fw.moreUrl;
+    a.textContent = fw.moreLabel || "Read more →";
+    el.fwNotes.appendChild(a);
+  }
 }
 
 function selectBadge(idx) {


### PR DESCRIPTION
You were right that the DOOM description was a partial lie. It stopped at *"it replaces the badge firmware"*, which reads as though flashing is the whole job — but the game data lives in QSPI and has to be uploaded separately. Someone following only the flasher ends up with a badge that has no game and no idea why, and would reasonably conclude DOOM was broken.

## Changes

**The description now says so**, and adds a reassurance that was missing: the pet and settings survive the switch. They do — only the application partition is rewritten.

> DOOM E1M1, rendered on the e-paper panel at a couple of frames per second, with the level's music on the buzzer. **Flashing this is only half the job: the game data is far too big for the USB drive, so you have to upload a WAD separately before DOOM will start.** It also replaces the badge firmware — no BornPets, mesh or clock until you flash one of those back, though your pet and settings survive in flash.

**A firmware entry can now carry `moreUrl` / `moreLabel`**, rendered as a link under the notes — so DOOM points straight at `../doom/`. It is built as an element rather than injected as markup, so the notes stay plain text and the registry cannot smuggle HTML into the page.

**The vanishing step 5 is replaced by a pointer.** An image with `wad = true` has no asset zip, so the asset step simply disappeared and left a hole in the numbering. It now stays put, explains that the data goes to QSPI over a serial connection, and links to the loader:

> **5. Add the game data** — DOOM keeps its game data in the badge's QSPI flash, not on the USB drive, so there is nothing to copy here. It is uploaded over a serial connection instead — and until you do that, the badge has no game to run. → *Upload the game data*

**The troubleshooting entry is reworded** — it described the step as disappearing, which is no longer what happens.

## Testing

New assertions in both suites, plus the existing ones:

```
  ok  DOOM notes mention the WAD upload
  ok  notes link to the DOOM page (../doom/)
  ok  link label: How to upload the WAD →
  ok  DOOM hides the asset copy step
  ok  DOOM shows the game-data pointer instead
  ok  pointer links to the DOOM page (../doom/)
  ok  pointer explains where the data goes
```

`hugo --gc --minify` clean, `reuse lint` green, and the asset and YMODEM suites still pass unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)