### PR TITLE
Fix the cyberaegg-doom repository URL

### DIFF
--- a/LICENSES/LicenseRef-DoomShareware.txt
+++ b/LICENSES/LicenseRef-DoomShareware.txt
@@ -8,7 +8,7 @@ The asset blob distributed here is derived from the freely distributable
 DOOM shareware episode ("Knee-Deep in the Dead", doom1.wad): the level and
 graphics lumps for E1M1 have been trimmed, re-packed and compressed by the
 CyberAegg DOOM asset pipeline (tools/wad*.py in
-https://github.com/annejan/cyberaegg-doom) so that they fit the badge's
+https://codeberg.org/rarenerd/cyberaegg-doom) so that they fit the badge's
 2 MB QSPI flash. It contains no data from the commercial DOOM episodes.
 
 id Software's shareware terms permit the shareware episode to be copied and

--- a/content/en/docs/Badges/Bornhack 2026/doom/_index.md
+++ b/content/en/docs/Badges/Bornhack 2026/doom/_index.md
@@ -77,7 +77,7 @@ sb --ymodem-1k e1m1.blob < /dev/ttyACM0 > /dev/ttyACM0
 Only one level fits: the blob offered above is about 1.8 MiB, roughly 92% of the
 badge's QSPI flash. It is built from the freely distributable **shareware**
 `doom1.wad`, trimmed and compressed by the asset pipeline in the
-[cyberaegg-doom](https://github.com/annejan/cyberaegg-doom) repository. DOOM and
+[cyberaegg-doom](https://codeberg.org/rarenerd/cyberaegg-doom) repository. DOOM and
 its game data remain the property of id Software.
 
 To build your own from a copy of `doom1.wad` you already have:
@@ -90,7 +90,7 @@ Then pick that file in the loader instead of the prepared one.
 
 ## Source
 
-The port lives at [annejan/cyberaegg-doom](https://github.com/annejan/cyberaegg-doom).
+The port lives at [rarenerd/cyberaegg-doom](https://codeberg.org/rarenerd/cyberaegg-doom).
 It is a fork of [next-hack/nRF52840Doom](https://github.com/next-hack/nRF52840Doom)
 (of prBoom and GBADoom lineage), re-fitted to the badge's e-paper display,
 buttons and power budget. The DOOM engine is licensed under the GPL.

--- a/data/firmwares.toml
+++ b/data/firmwares.toml
@@ -73,7 +73,7 @@ appPid = "0x0001"
 
   [[badge.firmware]]
   label = "DOOM"
-  # Built with `make -f Makefile.doom` in annejan/cyberaegg-doom,
+  # Built with `make -f Makefile.doom` in rarenerd/cyberaegg-doom,
   # from main @ dbad849 (2026-07-21). Links at 0x10000 like the others.
   file = "/firmware/cyber-aegg/cyber-aegg-doom.bin"
   sha256 = "c470cc78b6bf70348c0cd3f0f56e5c9e729867d16c91bfd8d06f18e36d8a4161"


### PR DESCRIPTION
My mistake: I wrote `github.com/annejan/cyberaegg-doom` from assumption rather than checking the remote. The port lives on Codeberg under `rarenerd`:

```
https://codeberg.org/rarenerd/cyberaegg-doom
```

Three places pointed at the dead URL, all shipped in #224:

| File | Context |
| --- | --- |
| `content/en/docs/Badges/Bornhack 2026/doom/_index.md` | The asset-pipeline link, and the Source section |
| `LICENSES/LicenseRef-DoomShareware.txt` | Provenance of the WAD blob we serve |
| `data/firmwares.toml` | Build-instructions comment on the DOOM entry |

That mattered beyond a broken link: the license file cites the repository as evidence for *what the blob is and how it was derived*, so a 404 undermined the provenance claim for the one payload here whose licensing needed the most care.

I re-checked the other repository references against each project's actual `git remote` rather than assuming. They are correct as they stand: `BornHack-Cyberegg` really is on GitHub under `annejan`, and `next-hack/nRF52840Doom` is the GitHub upstream this is forked from.

Hugo builds clean, `reuse lint` green, both DOOM links render to the Codeberg URL and no stale reference remains in the built site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)