### PR TITLE
Add the CircuitPython serial console, and finish the image list

### DIFF
--- a/content/en/docs/Badges/Bornhack 2026/_index.md
+++ b/content/en/docs/Badges/Bornhack 2026/_index.md
@@ -47,10 +47,11 @@ The Cyber Ægg is open source. Both the hardware design and the firmware live on
 * Hardware (KiCad) — [Ranzbak/bornhack2026-hardware](https://codeberg.org/Ranzbak/bornhack2026-hardware)
 * Firmware (Rust / Embassy) — [Ranzbak/bornhack-firmware-2026](https://codeberg.org/Ranzbak/bornhack-firmware-2026)
 
-The [Flash page](./flash/) also offers two alternative images, each with its own home:
+The [Flash page](./flash/) also offers three alternative images, each with its own home:
 
 * Community Edition — [ShadowSquad-org/BornHack-Cyberegg](https://github.com/ShadowSquad-org/BornHack-Cyberegg), a fork with extra BornPets mechanics
 * [DOOM](./doom/) — [rarenerd/cyberaegg-doom](https://codeberg.org/rarenerd/cyberaegg-doom), a bare-metal port of the DOOM engine
+* [CircuitPython](./circuitpython/) — [rarenerd/cyberaegg-circuitpython](https://codeberg.org/rarenerd/cyberaegg-circuitpython), for programming the badge in Python
 
 # Hardware sponsors
 

--- a/content/en/docs/Badges/Bornhack 2026/circuitpython/_index.md
+++ b/content/en/docs/Badges/Bornhack 2026/circuitpython/_index.md
@@ -57,6 +57,23 @@ For text, the firmware includes `terminalio` and `fontio`, so
 `adafruit_display_text` can draw labels — it is bundled in the repository's
 `lib/`.
 
+## The serial console
+
+CircuitPython prints `print()` output and tracebacks to a USB serial console,
+and offers a REPL there. That console is where you find out *why* a program did
+not run — errors never appear on the display.
+
+You can open it right here, without installing a terminal program:
+
+{{< repl >}}
+
+**Ctrl-C** interrupts whatever is running and gives you the `>>>` prompt, where
+you can poke at the hardware a line at a time. **Ctrl-D** restarts `code.py`
+from the top, which is the quickest way to re-run after an edit.
+
+The console is only available while CircuitPython is installed — it is the
+firmware that provides it, not the bootloader.
+
 ## Working with the e-paper display
 
 E-paper is the one part that does not behave like a normal screen, and most

--- a/layouts/_shortcodes/repl.html
+++ b/layouts/_shortcodes/repl.html
@@ -1,0 +1,51 @@
+{{- /*
+  Serial console for CircuitPython on the badge.
+
+  Web Serial, like the WAD loader — but a plain terminal rather than a file
+  transfer. Needs no firmware registry, so it takes no data and no arguments.
+
+  Usage in a page: call this shortcode by name, with no arguments.
+*/ -}}
+
+<link rel="stylesheet" href="/flash/flasher.css">
+
+<div id="repl" class="flasher">
+
+  <noscript>
+    <div class="alert alert-warning">
+      The console needs JavaScript. Any serial terminal will do instead, for
+      example <code>screen /dev/ttyACM0 115200</code>.
+    </div>
+  </noscript>
+
+  <div id="repl-unsupported" class="alert alert-danger d-none">
+    <strong>This browser has no serial support.</strong> Web Serial is required,
+    and only Chromium-family browsers ship it (Chrome, Edge, Brave, Opera, Arc).
+    Firefox and Safari do not. Use a terminal program instead —
+    <code>screen /dev/ttyACM0 115200</code>, <code>picocom</code>, or PuTTY on
+    Windows.
+  </div>
+
+  <div class="flasher-row">
+    <button id="btn-repl-connect" class="btn btn-primary">Connect to the badge</button>
+    <span id="repl-status" class="flasher-status">disconnected</span>
+    <button id="btn-repl-ctrlc" class="btn btn-secondary btn-sm" disabled
+            title="Interrupt the running program and get a REPL prompt">Ctrl-C</button>
+    <button id="btn-repl-ctrld" class="btn btn-secondary btn-sm" disabled
+            title="Soft reboot: re-run code.py from the start">Ctrl-D</button>
+    <button id="btn-repl-clear" class="btn btn-secondary btn-sm">Clear</button>
+  </div>
+
+  {{- /* tabindex makes the terminal focusable so it can take key events. */}}
+  <pre id="repl-term" class="repl-term" tabindex="0" role="log" aria-live="polite"
+       aria-label="CircuitPython serial console"></pre>
+
+  <p class="flasher-hint">
+    Click the console to type into it. <strong>Ctrl-C</strong> stops the running
+    program and drops you at the <code>&gt;&gt;&gt;</code> prompt;
+    <strong>Ctrl-D</strong> restarts <code>code.py</code> from the top. Paste
+    works as usual.
+  </p>
+</div>
+
+<script src="/flash/repl.js" type="module"></script>

--- a/static/flash/flasher.css
+++ b/static/flash/flasher.css
@@ -132,6 +132,27 @@
   font-size: 0.9rem;
 }
 
+/* Serial console. Focusable, so give it a visible focus ring — you have to
+   click into it before typing reaches the badge. */
+.repl-term {
+  height: 22rem;
+  overflow: auto;
+  margin: 0.75rem 0 0;
+  padding: 0.75rem;
+  border-radius: 0.375rem;
+  background: #1e1e1e;
+  color: #d4d4d4;
+  font-size: 0.85rem;
+  line-height: 1.45;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+.repl-term:focus-visible {
+  outline: 2px solid var(--bs-primary, #30638e);
+  outline-offset: 2px;
+}
+
 .flasher-diag summary {
   cursor: pointer;
   font-weight: 600;

--- a/static/flash/repl.js
+++ b/static/flash/repl.js
@@ -1,0 +1,248 @@
+// SPDX-FileCopyrightText: Stichting Badge.Team
+// SPDX-License-Identifier: MIT
+//
+// Serial terminal for CircuitPython on the badge.
+//
+// CircuitPython prints tracebacks and print() output to a USB serial console,
+// and offers a REPL there. Without this you need a terminal program (screen,
+// picocom, PuTTY) just to see why your code did not run — so the same Web
+// Serial support that uploads DOOM's WAD gets you a console in the page.
+//
+// The terminal is deliberately minimal: a line buffer with enough escape
+// handling for the REPL's own output (carriage returns, backspace, and the
+// erase-to-end-of-line it uses to redraw the prompt). It is not a VT100, and
+// full-screen curses-style programs will not render correctly.
+
+const $ = (id) => document.getElementById(id);
+
+const term = $("repl-term");
+if (!term) throw new Error("repl: markup not present");
+
+const el = {
+  status: $("repl-status"),
+  unsupported: $("repl-unsupported"),
+  btnConnect: $("btn-repl-connect"),
+  btnCtrlC: $("btn-repl-ctrlc"),
+  btnCtrlD: $("btn-repl-ctrld"),
+  btnClear: $("btn-repl-clear"),
+};
+
+// --------------------------------------------------------------------------
+// Terminal
+// --------------------------------------------------------------------------
+
+const MAX_LINES = 1000;
+let lines = [];
+let cur = "";
+let curPos = 0;
+let esc = null;
+
+function render() {
+  term.textContent = lines.join("\n") + (lines.length ? "\n" : "") + cur;
+  term.scrollTop = term.scrollHeight;
+}
+
+function feed(text) {
+  for (const ch of text) {
+    if (esc !== null) {
+      esc += ch;
+      // A CSI sequence ends at a letter. The only one worth honouring here is
+      // K (erase to end of line), which the REPL uses to redraw the prompt.
+      if (/[A-Za-z]/.test(ch)) {
+        if (esc.endsWith("K")) cur = cur.slice(0, curPos);
+        esc = null;
+      }
+      continue;
+    }
+    if (ch === "\x1b") {
+      esc = "";
+    } else if (ch === "\n") {
+      lines.push(cur);
+      if (lines.length > MAX_LINES) lines.shift();
+      cur = "";
+      curPos = 0;
+    } else if (ch === "\r") {
+      curPos = 0;
+    } else if (ch === "\b") {
+      curPos = Math.max(0, curPos - 1);
+    } else if (ch === "\x07") {
+      // bell — ignore
+    } else {
+      cur = cur.slice(0, curPos) + ch + cur.slice(curPos + 1);
+      curPos++;
+    }
+  }
+  render();
+}
+
+const sysMsg = (msg) => feed(`\r\n[${msg}]\r\n`);
+
+// --------------------------------------------------------------------------
+// Web Serial
+// --------------------------------------------------------------------------
+
+let port = null;
+let writer = null;
+let connected = false;
+const encoder = new TextEncoder();
+
+function setConnected(on) {
+  connected = on;
+  el.status.textContent = on ? "connected" : "disconnected";
+  el.status.classList.toggle("connected", on);
+  el.btnConnect.textContent = on ? "Disconnect" : "Connect to the badge";
+  el.btnCtrlC.disabled = !on;
+  el.btnCtrlD.disabled = !on;
+}
+
+async function send(str) {
+  if (!writer) return;
+  try {
+    await writer.write(encoder.encode(str));
+  } catch {
+    /* the port went away; readLoop will notice and disconnect */
+  }
+}
+
+async function readLoop() {
+  const decoder = new TextDecoder();
+  while (port && port.readable) {
+    const reader = port.readable.getReader();
+    try {
+      for (;;) {
+        const { value, done } = await reader.read();
+        if (done) break;
+        feed(decoder.decode(value, { stream: true }));
+      }
+    } catch {
+      break; // unplugged mid-read
+    } finally {
+      reader.releaseLock();
+    }
+  }
+  disconnect(true);
+}
+
+async function connect() {
+  let p;
+  try {
+    p = await navigator.serial.requestPort();
+  } catch {
+    return; // cancelled
+  }
+  try {
+    await p.open({ baudRate: 115200 });
+  } catch (e) {
+    sysMsg(`could not open the port: ${e.message || e}`);
+    return;
+  }
+  port = p;
+  writer = port.writable.getWriter();
+  setConnected(true);
+  sysMsg("connected — press Ctrl-C for the REPL prompt");
+  term.focus();
+  readLoop();
+}
+
+async function disconnect(fromError) {
+  if (!port) return;
+  const p = port;
+  port = null;
+  try {
+    writer?.releaseLock();
+  } catch {
+    /* already released */
+  }
+  writer = null;
+  try {
+    await p.close();
+  } catch {
+    /* already gone */
+  }
+  if (connected) {
+    setConnected(false);
+    sysMsg(fromError ? "connection lost" : "disconnected");
+  }
+}
+
+// --------------------------------------------------------------------------
+// Keyboard
+// --------------------------------------------------------------------------
+
+const KEYS = {
+  Enter: "\r",
+  Backspace: "\x7f",
+  Tab: "\t",
+  Escape: "\x1b",
+  ArrowUp: "\x1b[A",
+  ArrowDown: "\x1b[B",
+  ArrowRight: "\x1b[C",
+  ArrowLeft: "\x1b[D",
+  Home: "\x1b[H",
+  End: "\x1b[F",
+  Delete: "\x1b[3~",
+};
+
+term.addEventListener("keydown", (e) => {
+  if (!connected) return;
+
+  if (e.ctrlKey && !e.altKey && e.key.length === 1) {
+    const c = e.key.toLowerCase().charCodeAt(0);
+    if (c >= 97 && c <= 122) {
+      // Leave Ctrl-C alone when there is a selection, so copying still works.
+      if (e.key.toLowerCase() === "c" && window.getSelection()?.toString()) {
+        return;
+      }
+      e.preventDefault();
+      send(String.fromCharCode(c - 96));
+      return;
+    }
+  }
+
+  if (KEYS[e.key]) {
+    e.preventDefault();
+    send(KEYS[e.key]);
+    return;
+  }
+  if (e.key.length === 1 && !e.ctrlKey && !e.metaKey && !e.altKey) {
+    e.preventDefault();
+    send(e.key);
+  }
+});
+
+term.addEventListener("paste", (e) => {
+  if (!connected) return;
+  e.preventDefault();
+  send(e.clipboardData.getData("text"));
+});
+
+// --------------------------------------------------------------------------
+// Wiring
+// --------------------------------------------------------------------------
+
+if (!("serial" in navigator)) {
+  el.unsupported.classList.remove("d-none");
+  el.btnConnect.disabled = true;
+} else {
+  el.btnConnect.addEventListener("click", () =>
+    connected ? disconnect(false) : connect(),
+  );
+  el.btnCtrlC.addEventListener("click", () => {
+    send("\x03");
+    term.focus();
+  });
+  el.btnCtrlD.addEventListener("click", () => {
+    send("\x04");
+    term.focus();
+  });
+  navigator.serial.addEventListener?.("disconnect", () => disconnect(true));
+}
+
+el.btnClear.addEventListener("click", () => {
+  lines = [];
+  cur = "";
+  curPos = 0;
+  render();
+});
+
+setConnected(false);


### PR DESCRIPTION
CircuitPython prints tracebacks and `print()` output to a USB serial console, and that console is the **only** place errors appear — nothing shows on the e-paper. Until now the page told people to go and open a terminal program to see it, which is a real barrier for exactly the audience this firmware is for.

So the console is now embedded in the CircuitPython page, over the same Web Serial support that uploads DOOM's WAD. Ported from `repl.html` in the standalone flasher.

*(This is the thing I noticed while porting DOOM and then never mentioned — my omission. Doing it now.)*

## What it does

Connect, and you get live output plus a REPL you can type into. **Ctrl-C** interrupts the running program and gives you a `>>>` prompt; **Ctrl-D** restarts `code.py` from the top. Both are buttons as well as keystrokes — those two *are* the workflow, and a terminal you have to already know the shortcuts for is not much of an improvement.

The terminal is deliberately small: a line buffer that handles carriage returns, backspace, and the erase-to-end-of-line the REPL uses to redraw its prompt. It is not a VT100, and full-screen curses-style programs will not render — which is fine for what this is.

One subtlety worth keeping in review: **Ctrl-C is passed to the browser rather than the badge when text is selected**, so copying output still works.

## Also here

The CircuitPython line for the badge landing page's list of alternative images, which I left out of #228 to avoid conflicting with #227. Both have landed, so it goes in cleanly now.

## Testing

The terminal emulation and key mapping are tested against a fake serial port, feeding it the kind of output CircuitPython actually produces:

```
  ok  banner rendered
  ok  prompt on the last line
  ok  traceback rendered
  ok  erase-to-end-of-line redraws cleanly (got ">>> print(1)")
  ok  backspace moves the cursor back
  ok  a letter is sent as-is
  ok  Enter sends CR
  ok  ArrowUp sends the CSI sequence (history)
  ok  Backspace sends DEL
  ok  Ctrl-C sends an interrupt
  ok  Ctrl-C with a selection is left for copying
  ok  Ctrl-C button sends an interrupt
  ok  Ctrl-D button sends a soft reboot
  ok  paste is forwarded
  ok  clear empties the terminal
```

Hugo builds clean, `reuse lint` green, and the flasher, asset and YMODEM suites all still pass.

**Not tested against real hardware** — a genuine badge running CircuitPython is the remaining check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)