### PR TITLE
Fix the serial console rendering grey on grey

### DIFF
--- a/static/flash/flasher.css
+++ b/static/flash/flasher.css
@@ -133,12 +133,19 @@
 }
 
 /* Serial console. Focusable, so give it a visible focus ring — you have to
-   click into it before typing reaches the badge. */
-.repl-term {
+   click into it before typing reaches the badge.
+ *
+ * Selector deliberately over-qualified: Docsy styles `.td-content pre` with a
+ * light background, which outranks a bare `.repl-term` and left the console
+ * grey-on-grey (it sets background-color but not color, so only half of it
+ * lost). `.flasher pre.repl-term` outranks it. Same reason for the
+ * diagnostics pane below. */
+.flasher pre.repl-term {
   height: 22rem;
   overflow: auto;
   margin: 0.75rem 0 0;
   padding: 0.75rem;
+  border: 0;
   border-radius: 0.375rem;
   background: #1e1e1e;
   color: #d4d4d4;
@@ -148,7 +155,7 @@
   overflow-wrap: anywhere;
 }
 
-.repl-term:focus-visible {
+.flasher pre.repl-term:focus-visible {
   outline: 2px solid var(--bs-primary, #30638e);
   outline-offset: 2px;
 }
@@ -158,10 +165,11 @@
   font-weight: 600;
 }
 
-.flasher-diag pre {
+.flasher .flasher-diag pre {
   max-height: 18rem;
   overflow: auto;
   padding: 0.75rem;
+  border: 0;
   border-radius: 0.375rem;
   background: #1e1e1e;
   color: #d4d4d4;


### PR DESCRIPTION
The console was unreadable — light grey text on the theme's light background, exactly as reported.

## Cause

Docsy styles code blocks generically:

```css
.td-content pre { background-color: var(--td-pre-bg); ... }   /* 0,0,1,1 */
.repl-term      { background: #1e1e1e; color: #d4d4d4; }      /* 0,0,1,0 */
```

The theme selector outranks a bare class, so my background lost. But it only sets `background-color`, not `color` — so the *text* colour still applied. That asymmetry is what produced grey-on-grey rather than simply falling back to the theme's readable defaults: half my rule won and half lost.

## Fix

Qualify the selectors so they outrank the theme, and drop the border it was adding:

- `.flasher pre.repl-term` — 0,0,2,1
- `.flasher .flasher-diag pre` — 0,0,2,1 (the diagnostics panes on the flasher and WAD loader pages had the same latent weakness; they only rendered correctly because our stylesheet happens to load last)

I checked this against the **compiled** theme stylesheet rather than assuming: the only rules that can match a plain `pre` here are the bare element selector, `.td-content pre`, and `.td-content .highlight pre` (which needs a `.highlight` ancestor we do not have). Both applicable ones are now lower specificity, and our stylesheet loads after the theme's as well, so it wins on either count.

`hugo --gc --minify` builds clean, `reuse lint` green, and the REPL test suite still passes.

Worth noting this was only ever a rendering bug — the console itself worked, which is why the tests (which assert on `textContent`) stayed green throughout. Thanks for the screenshot; that was the only way to catch it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)