### PR TITLE
Add a Paste button to the serial console

### DIFF
--- a/layouts/_shortcodes/repl.html
+++ b/layouts/_shortcodes/repl.html
@@ -33,6 +33,8 @@
             title="Interrupt the running program and get a REPL prompt">Ctrl-C</button>
     <button id="btn-repl-ctrld" class="btn btn-secondary btn-sm" disabled
             title="Soft reboot: re-run code.py from the start">Ctrl-D</button>
+    <button id="btn-repl-paste" class="btn btn-secondary btn-sm" disabled
+            title="Send the clipboard to the badge">Paste</button>
     <button id="btn-repl-clear" class="btn btn-secondary btn-sm">Clear</button>
   </div>
 
@@ -43,8 +45,10 @@
   <p class="flasher-hint">
     Click the console to type into it. <strong>Ctrl-C</strong> stops the running
     program and drops you at the <code>&gt;&gt;&gt;</code> prompt;
-    <strong>Ctrl-D</strong> restarts <code>code.py</code> from the top. Paste
-    works as usual.
+    <strong>Ctrl-D</strong> restarts <code>code.py</code> from the top.
+    <strong>Ctrl-V</strong> pastes into the console once it has focus, and the
+    <strong>Paste</strong> button does the same without needing focus — handy
+    for pasting an example straight from this page.
   </p>
 </div>
 

--- a/static/flash/repl.js
+++ b/static/flash/repl.js
@@ -24,6 +24,7 @@ const el = {
   btnConnect: $("btn-repl-connect"),
   btnCtrlC: $("btn-repl-ctrlc"),
   btnCtrlD: $("btn-repl-ctrld"),
+  btnPaste: $("btn-repl-paste"),
   btnClear: $("btn-repl-clear"),
 };
 
@@ -93,6 +94,31 @@ function setConnected(on) {
   el.btnConnect.textContent = on ? "Disconnect" : "Connect to the badge";
   el.btnCtrlC.disabled = !on;
   el.btnCtrlD.disabled = !on;
+  el.btnPaste.disabled = !on;
+}
+
+// Ctrl-V already works once the terminal has focus, via the paste event. The
+// button covers the case where it does not — you have just copied an example
+// from the page, and focus is still wherever you selected it.
+async function pasteFromClipboard() {
+  if (!navigator.clipboard?.readText) {
+    sysMsg("this browser will not hand over the clipboard — click the console and press Ctrl-V");
+    return;
+  }
+  let text;
+  try {
+    text = await navigator.clipboard.readText();
+  } catch {
+    // Denied, or no permission prompt was possible.
+    sysMsg("clipboard access was refused — click the console and press Ctrl-V");
+    return;
+  }
+  if (!text) {
+    sysMsg("the clipboard is empty");
+    return;
+  }
+  await send(text);
+  term.focus();
 }
 
 async function send(str) {
@@ -235,6 +261,7 @@ if (!("serial" in navigator)) {
     send("\x04");
     term.focus();
   });
+  el.btnPaste.addEventListener("click", pasteFromClipboard);
   navigator.serial.addEventListener?.("disconnect", () => disconnect(true));
 }
 


### PR DESCRIPTION
Ctrl-V already worked, but only once the console had focus — and the common case is copying an example from the page above, where focus is still sitting in the text you just selected. The button reads the clipboard directly, so the paste reaches the badge either way.

## Failing loudly

A refused clipboard permission is otherwise indistinguishable from a paste that quietly did nothing, so both that and an empty clipboard now say so in the console and point at the Ctrl-V route:

```
[clipboard access was refused — click the console and press Ctrl-V]
[the clipboard is empty]
```

Same for a browser with no `navigator.clipboard.readText` at all.

## Testing

```
  ok  Paste button enabled once connected
  ok  Paste button sends the clipboard
  ok  empty clipboard sends nothing
  ok  empty clipboard is reported
  ok  refused clipboard sends nothing
  ok  refused clipboard points at the Ctrl-V fallback
```

The existing Ctrl-V path is still covered too. Hugo builds clean, `reuse lint` green.

Note this stacks with #230 (the grey-on-grey fix), which is still open and touches only the stylesheet — no overlap, they can merge in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)