### PR TITLE
Paste multi-line code correctly, and link the examples

### DIFF
--- a/content/en/docs/Badges/Bornhack 2026/circuitpython/_index.md
+++ b/content/en/docs/Badges/Bornhack 2026/circuitpython/_index.md
@@ -51,7 +51,13 @@ display = cyberaegg_epd.get_display()
 
 The example `epd_hello.py` draws a bordered white field with a black and a red
 square; `hwtest.py` walks through the LED, buzzer, charger, battery, I²C and all
-the buttons. Both are in the repository's `examples/` directory.
+the buttons.
+
+**→ [Browse all the examples](https://codeberg.org/rarenerd/cyberaegg-circuitpython/src/branch/main/examples)**
+· [the libraries](https://codeberg.org/rarenerd/cyberaegg-circuitpython/src/branch/main/lib)
+
+Copy any of them into the console below with **Paste**, or save one as
+`code.py` on the drive.
 
 For text, the firmware includes `terminalio` and `fontio`, so
 `adafruit_display_text` can draw labels — it is bundled in the repository's
@@ -169,7 +175,10 @@ last one and the request is ignored. Wait out the interval, or use
 ## Source
 
 The firmware, library and examples live at
-[rarenerd/cyberaegg-circuitpython](https://codeberg.org/rarenerd/cyberaegg-circuitpython).
+[rarenerd/cyberaegg-circuitpython](https://codeberg.org/rarenerd/cyberaegg-circuitpython)
+— go straight to the
+[examples](https://codeberg.org/rarenerd/cyberaegg-circuitpython/src/branch/main/examples)
+or the [libraries](https://codeberg.org/rarenerd/cyberaegg-circuitpython/src/branch/main/lib).
 The image offered on the Flash page is that repository's prebuilt binary, byte
 for byte — its checksum matches the `SHA256SUMS` published alongside it. Build
 instructions are in the repository's `docs/BUILDING.md`.

--- a/layouts/_shortcodes/repl.html
+++ b/layouts/_shortcodes/repl.html
@@ -48,7 +48,9 @@
     <strong>Ctrl-D</strong> restarts <code>code.py</code> from the top.
     <strong>Ctrl-V</strong> pastes into the console once it has focus, and the
     <strong>Paste</strong> button does the same without needing focus — handy
-    for pasting an example straight from this page.
+    for pasting an example straight from this page. Multi-line code goes in
+    through the REPL's paste mode, so its indentation survives and it runs as
+    one block.
   </p>
 </div>
 

--- a/static/flash/repl.js
+++ b/static/flash/repl.js
@@ -74,9 +74,39 @@ function feed(text) {
     }
   }
   render();
+  noteOutput(text);
 }
 
 const sysMsg = (msg) => feed(`\r\n[${msg}]\r\n`);
+
+// Lets the paste path wait for something the badge prints back. Matching is
+// done on a rolling tail rather than the whole buffer, so a phrase left over
+// from an earlier paste cannot satisfy a later wait.
+let watcher = null;
+let recentOutput = "";
+
+function noteOutput(text) {
+  if (!watcher) return;
+  recentOutput = (recentOutput + text).slice(-256);
+  if (recentOutput.includes(watcher.needle)) {
+    const w = watcher;
+    watcher = null;
+    w.resolve(true);
+  }
+}
+
+function waitForText(needle, timeoutMs) {
+  recentOutput = "";
+  return new Promise((resolve) => {
+    watcher = { needle, resolve };
+    setTimeout(() => {
+      if (watcher?.resolve === resolve) {
+        watcher = null;
+        resolve(false);
+      }
+    }, timeoutMs);
+  });
+}
 
 // --------------------------------------------------------------------------
 // Web Serial
@@ -95,6 +125,43 @@ function setConnected(on) {
   el.btnCtrlC.disabled = !on;
   el.btnCtrlD.disabled = !on;
   el.btnPaste.disabled = !on;
+}
+
+// The REPL takes carriage return as Enter and ignores a bare line feed, so
+// clipboard text pasted verbatim arrives as one run-on line. Translate every
+// flavour of line ending to CR.
+const toCr = (text) => text.replace(/\r\n|\r|\n/g, "\r");
+
+/**
+ * Paste text as a human would, but without the damage.
+ *
+ * Sending multi-line code straight at the prompt gets it mangled: the REPL
+ * echoes its own indentation after `if x:` and friends, which compounds with
+ * the indentation already in the text. CircuitPython has paste mode for
+ * exactly this — Ctrl-E in, Ctrl-D to run — where it takes the text literally.
+ *
+ * Ctrl-D only means "execute" *inside* paste mode; at a normal prompt it is a
+ * soft reboot. So we confirm the badge really entered paste mode before
+ * sending it, and fall back to a plain paste if it did not.
+ */
+async function sendPaste(text) {
+  const body = toCr(text);
+  if (!body.includes("\r")) {
+    await send(body); // single line — nothing to protect it from
+    return;
+  }
+
+  await send("\x05"); // Ctrl-E
+  if (await waitForText("paste mode", 750)) {
+    await send(body);
+    await send("\x04"); // Ctrl-D — runs it, because we are in paste mode
+    return;
+  }
+
+  // No paste mode: maybe a program is running, or this is not a REPL at all.
+  // Send the text as-is and leave the trailing Ctrl-D well alone.
+  sysMsg("could not enter paste mode — pasting line by line instead");
+  await send(body);
 }
 
 // Ctrl-V already works once the terminal has focus, via the paste event. The
@@ -117,7 +184,7 @@ async function pasteFromClipboard() {
     sysMsg("the clipboard is empty");
     return;
   }
-  await send(text);
+  await sendPaste(text);
   term.focus();
 }
 
@@ -239,7 +306,7 @@ term.addEventListener("keydown", (e) => {
 term.addEventListener("paste", (e) => {
   if (!connected) return;
   e.preventDefault();
-  send(e.clipboardData.getData("text"));
+  sendPaste(e.clipboardData.getData("text"));
 });
 
 // --------------------------------------------------------------------------


### PR DESCRIPTION
## The bug you hit

The REPL treats **carriage return** as Enter and ignores a bare **line feed**. Clipboard text carries LF, and we sent it verbatim — so every line break was silently dropped and the lines ran together with nothing between them, exactly as you saw.

Fixed by translating every flavour of line ending to CR on the way out.

## That alone was not enough

Sending several lines straight at the prompt still mangles them: after a block opener like `if x:` the REPL inserts *its own* indentation, which compounds with the indentation already in the pasted text. Paste an example and you get drifting indentation, or an `IndentationError`.

CircuitPython has **paste mode** for exactly this — it takes input literally. Ctrl-E enters, Ctrl-D runs.

The catch worth reviewing: **Ctrl-D only means "run" inside paste mode.** At a normal prompt it is a soft reboot. So rather than firing it blind, the badge has to confirm it really entered paste mode — it prints a `paste mode; Ctrl-C to cancel, Ctrl-D to finish` banner — before we send the terminator. If that confirmation never arrives (a program is running, something else is on the port), the text is still pasted, the Ctrl-D is withheld, and the console says why:

```
[could not enter paste mode — pasting line by line instead]
```

A single-line paste skips the whole dance.

## Also here

Direct links to the [examples](https://codeberg.org/rarenerd/cyberaegg-circuitpython/src/branch/main/examples) and [libraries](https://codeberg.org/rarenerd/cyberaegg-circuitpython/src/branch/main/lib), from both the first-program section and the Source section — pasting one of them in is the whole point of having the console there.

## Testing

```
  ok  no bare line feeds are sent
  ok  line endings become CR
  ok  enters paste mode first (Ctrl-E)
  ok  finishes with Ctrl-D to run it
  ok  no Ctrl-D when paste mode was not confirmed (would soft reboot)
  ok  text is still pasted as a fallback
  ok  fallback is explained
  ok  single line is sent plainly
```

Two older assertions changed rather than broke: they pasted text with a trailing CR, which now correctly takes the paste-mode path, so they were narrowed to the single-line case they were actually testing.

Hugo builds clean, `reuse lint` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
