### PR TITLE
Offer the CircuitPython libraries at step 5 of the flasher

### DIFF
--- a/data/firmwares.toml
+++ b/data/firmwares.toml
@@ -102,7 +102,19 @@ appPid = "0x0001"
   notes = "Write badge programs in Python, with no toolchain at all: the badge mounts as a CIRCUITPY drive and runs code.py every time you save it. The display, buttons, LEDs, buzzer, battery, LoRa and NFC are all exposed as ordinary CircuitPython modules. Bluetooth is not, and it replaces the badge firmware — no BornPets, mesh or clock until you flash one of those back."
   moreUrl = "../circuitpython/"
   moreLabel = "Getting started with CircuitPython →"
-  nextStep = "CircuitPython has no asset bundle to copy. Once it is flashed the badge mounts as a CIRCUITPY drive instead, and you drop your own Python files onto that — starting with a library and an example."
+  # Support libraries for the CIRCUITPY drive. Declared as this image's asset
+  # payload so the flasher offers them at step 5 like any other, and repeated
+  # as `pylib` below for the installer on the CircuitPython page.
+  #
+  # `drive` names the volume to pick. CircuitPython's is not the badge's own
+  # CYBR volume: that one only exists in DFU mode, while CIRCUITPY appears
+  # once the badge has been reset into the new firmware.
+  [badge.firmware.assets]
+  file = "/assets/cyber-aegg/cyberaegg-circuitpython-lib.zip"
+  sha256 = "8905601ff13fa069770ded3a6007a96f2e88475e7f31714a46fc41d5bd734bf5"
+  label = "8 files — the e-paper and LoRa drivers, plus adafruit_display_text for drawing labels."
+  drive = "CIRCUITPY"
+  intro = "CircuitPython needs its support libraries before any of the examples will run. They go in a lib folder on the CIRCUITPY drive, which appears once you have flashed the firmware and reset the badge — it is not the CYBR drive you flashed from."
 
   # Support libraries for the CIRCUITPY drive, offered by the installer on
   # ../circuitpython/. Unlike the badge's own asset archives this one has

--- a/layouts/_shortcodes/flasher.html
+++ b/layouts/_shortcodes/flasher.html
@@ -94,7 +94,7 @@
 
   <section class="flasher-step" id="assets-card">
     <h3><span class="flasher-num">5</span> Add the asset files</h3>
-    <p>
+    <p id="assets-intro">
       Firmware alone leaves the badge without artwork. In DFU mode it also
       appears as a small USB drive named <code>CYBR</code> followed by four hex
       digits; the sprites, sponsor slides and the event programme belong in the
@@ -104,7 +104,7 @@
     <p id="assets-summary" class="flasher-hint"></p>
 
     <h4 class="flasher-sub">Copy them straight to the drive</h4>
-    <p class="flasher-hint">
+    <p class="flasher-hint" id="assets-drive-hint">
       Pick the <code>CYBR…</code> drive when your browser asks, and the files
       are written for you — no download, no unzipping.
     </p>

--- a/static/flash/assets.js
+++ b/static/flash/assets.js
@@ -11,11 +11,17 @@
 //   B. Write the files straight onto the badge drive with the File System
 //      Access API, so there is no download-and-unzip step at all.
 //
-// For (B) the zip is unpacked in the browser — see zip.js. This payload is
-// deliberately flat: the badge's FAT12 volume wants every file in its root, so
-// entry names are reduced to their basename on the way out.
+// For (B) the zip is unpacked in the browser — see zip.js. The badge's own
+// archives are flat, since its FAT12 volume wants everything in the root, but
+// CircuitPython's libraries live under lib/, so any directories in the archive
+// are recreated. safePath() keeps that from escaping the chosen folder.
 
-import { readCentralDirectory, inflateEntry, sha256Hex } from "./zip.js";
+import {
+  readCentralDirectory,
+  inflateEntry,
+  safePath,
+  sha256Hex,
+} from "./zip.js";
 
 const $ = (id) => document.getElementById(id);
 
@@ -37,12 +43,18 @@ const el = {
   progress: $("assets-progress"),
   progLabel: $("assets-progress-label"),
   log: $("log"),
+  intro: $("assets-intro"),
+  driveHint: $("assets-drive-hint"),
   elsewhere: $("assets-elsewhere"),
   elsewhereText: $("assets-elsewhere-text"),
   elsewhereLink: $("assets-elsewhere-link"),
 };
 
 let badge = badges[0];
+
+// Kept so the wording can be restored when switching back to an image that
+// does not override it.
+const DEFAULT_INTRO = el.intro ? el.intro.textContent : "";
 
 function logLine(msg, cls) {
   if (!el.log) return;
@@ -59,6 +71,15 @@ const logErr = (m) => logLine(m, "err");
 // --------------------------------------------------------------------------
 // Copying to the badge drive
 // --------------------------------------------------------------------------
+
+/** Walk down, creating as needed, to the directory an entry belongs in. */
+async function ensureDir(root, dirs) {
+  let handle = root;
+  for (const part of dirs) {
+    handle = await handle.getDirectoryHandle(part, { create: true });
+  }
+  return handle;
+}
 
 async function wipeDirectory(dir) {
   const names = [];
@@ -125,16 +146,18 @@ async function copyToBadge() {
 
     for (let i = 0; i < entries.length; i++) {
       const entry = entries[i];
+      const path = safePath(entry.name);
+      if (!path) {
+        logErr(`skipped a suspicious path: ${entry.name}`);
+        continue;
+      }
       const data = await inflateEntry(buf, entry);
-      // Entries are flat filenames; guard anyway so a crafted archive cannot
-      // escape the directory the user picked.
-      const name = entry.name.split("/").pop();
-      if (!name || name === "." || name === "..") continue;
-      const handle = await root.getFileHandle(name, { create: true });
+      const dir = await ensureDir(root, path.dirs);
+      const handle = await dir.getFileHandle(path.name, { create: true });
       const writable = await handle.createWritable();
       await writable.write(data);
       await writable.close();
-      setProgress(i + 1, entries.length, `${i + 1}/${entries.length} ${name}`);
+      setProgress(i + 1, entries.length, `${i + 1}/${entries.length} ${path.name}`);
     }
 
     setProgress(entries.length, entries.length, "done — now eject the drive");
@@ -188,6 +211,16 @@ function refresh() {
   card.classList.remove("d-none");
   el.zipLink.href = assets.file;
   el.summary.textContent = assets.label || "";
+
+  // CircuitPython's libraries go to CIRCUITPY, not the badge's own CYBR
+  // volume, so let the payload override the wording rather than sending
+  // people to the wrong drive.
+  if (assets.intro) el.intro.textContent = assets.intro;
+  else el.intro.textContent = DEFAULT_INTRO;
+  const drive = assets.drive ? `${assets.drive}` : "CYBR…";
+  el.driveHint.textContent =
+    `Pick the ${drive} drive when your browser asks, and the files are written for you — no download, no unzipping.`;
+
   setProgress(0, 1, "idle");
 }
 


### PR DESCRIPTION
Selecting CircuitPython on the flash page showed only a link to another page, because that image had no asset payload registered. It does have one — its support libraries — and there is no reason they cannot be installed from the same place as every other image's assets. Step 5 now offers them properly.

## The obstacle turned out not to be one

I originally kept CircuitPython out of step 5 because its payload has directory structure (`lib/`, `lib/adafruit_display_text/`) while the copier flattened entry names.

But the flattening was only ever a guard against an archive escaping the chosen folder — and `safePath()` (added with the library installer) does that properly now, rejecting absolute paths, drive letters and traversal. So the copier recreates directories instead.

The badge's own archives are flat and come out **exactly as before**; the tests still check all 171 and 265 files byte for byte.

## Different volumes, different wording

The one thing that genuinely differs is which drive to pick, and getting it wrong wastes real time:

- **`CYBR…`** — the badge's own storage, only present in DFU mode
- **`CIRCUITPY`** — appears once the badge is reset into CircuitPython

So the intro and the drive hint now come from the payload, falling back to the badge wording, and switching images switches the wording back:

> Pick the **CIRCUITPY** drive when your browser asks, and the files are written for you — no download, no unzipping.

The installer on the CircuitPython page stays as it is — that is where someone lands following the docs rather than the flasher.

## Testing

```
  ok  CircuitPython shows the asset copy step
  ok  ...and not the elsewhere pointer
  ok  intro names the CIRCUITPY drive
  ok  drive hint names CIRCUITPY
  ok  libraries copied
  ok  nested package copied
  ok  switching back restores the CYBR wording
  ok  copied 171 files, expected 171
  ok  byte-identical after inflate (0 mismatched)
  ok  copied 265 files, expected 265
  ok  byte-identical after inflate (0 mismatched)
```

The fake drive in the asset tests only implemented flat file creation, so it needed directory support to exercise this — which is also what proved the nested path was being taken. DOOM still shows its pointer, since its data really does go somewhere the flasher cannot reach. Hugo builds clean, `reuse lint` green, all five suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
