### PR TITLE
Make the serial console resizable and fullscreenable

### DIFF
--- a/layouts/_shortcodes/repl.html
+++ b/layouts/_shortcodes/repl.html
@@ -26,21 +26,27 @@
     Windows.
   </div>
 
-  <div class="flasher-row">
-    <button id="btn-repl-connect" class="btn btn-primary">Connect to the badge</button>
-    <span id="repl-status" class="flasher-status">disconnected</span>
-    <button id="btn-repl-ctrlc" class="btn btn-secondary btn-sm" disabled
-            title="Interrupt the running program and get a REPL prompt">Ctrl-C</button>
-    <button id="btn-repl-ctrld" class="btn btn-secondary btn-sm" disabled
-            title="Soft reboot: re-run code.py from the start">Ctrl-D</button>
-    <button id="btn-repl-paste" class="btn btn-secondary btn-sm" disabled
-            title="Send the clipboard to the badge">Paste</button>
-    <button id="btn-repl-clear" class="btn btn-secondary btn-sm">Clear</button>
+  {{- /* The shell wraps the toolbar and the terminal, so both come along when
+         it goes fullscreen. tabindex makes the terminal focusable for key
+         events; the drag handle in the bottom-right corner is the CSS resize
+         affordance. */}}
+  <div id="repl-shell" class="repl-shell">
+    <div class="flasher-row repl-toolbar">
+      <button id="btn-repl-connect" class="btn btn-primary">Connect to the badge</button>
+      <span id="repl-status" class="flasher-status">disconnected</span>
+      <button id="btn-repl-ctrlc" class="btn btn-secondary btn-sm" disabled
+              title="Interrupt the running program and get a REPL prompt">Ctrl-C</button>
+      <button id="btn-repl-ctrld" class="btn btn-secondary btn-sm" disabled
+              title="Soft reboot: re-run code.py from the start">Ctrl-D</button>
+      <button id="btn-repl-paste" class="btn btn-secondary btn-sm" disabled
+              title="Send the clipboard to the badge">Paste</button>
+      <button id="btn-repl-clear" class="btn btn-secondary btn-sm">Clear</button>
+      <button id="btn-repl-fullscreen" class="btn btn-secondary btn-sm"
+              title="Fill the screen with the console" aria-pressed="false">Fullscreen</button>
+    </div>
+    <pre id="repl-term" class="repl-term" tabindex="0" role="log" aria-live="polite"
+         aria-label="CircuitPython serial console"></pre>
   </div>
-
-  {{- /* tabindex makes the terminal focusable so it can take key events. */}}
-  <pre id="repl-term" class="repl-term" tabindex="0" role="log" aria-live="polite"
-       aria-label="CircuitPython serial console"></pre>
 
   <p class="flasher-hint">
     Click the console to type into it. <strong>Ctrl-C</strong> stops the running
@@ -51,6 +57,10 @@
     for pasting an example straight from this page. Multi-line code goes in
     through the REPL's paste mode, so its indentation survives and it runs as
     one block.
+  </p>
+  <p class="flasher-hint">
+    Drag the bottom-right corner to resize the console, or use
+    <strong>Fullscreen</strong> for the whole screen (<kbd>Esc</kbd> leaves it).
   </p>
 </div>
 

--- a/static/flash/flasher.css
+++ b/static/flash/flasher.css
@@ -140,10 +140,31 @@
  * grey-on-grey (it sets background-color but not color, so only half of it
  * lost). `.flasher pre.repl-term` outranks it. Same reason for the
  * diagnostics pane below. */
-.flasher pre.repl-term {
-  height: 22rem;
-  overflow: auto;
+/* The shell wraps the toolbar and terminal and owns the drag-to-resize handle;
+   the terminal flexes to fill whatever is left. Resizing the shell keeps the
+   corner grip clear of the terminal's own scrollbar, and lets fullscreen
+   restyle a single element that already contains the controls. */
+.flasher .repl-shell {
+  display: flex;
+  flex-direction: column;
   margin: 0.75rem 0 0;
+  height: 24rem;
+  min-height: 10rem;
+  /* Vertical only: horizontal scrolling a wrapped terminal gains nothing. */
+  resize: vertical;
+  overflow: hidden;
+}
+
+.flasher .repl-shell .repl-toolbar {
+  margin: 0 0 0.5rem;
+  flex: 0 0 auto;
+}
+
+.flasher pre.repl-term {
+  flex: 1 1 auto;
+  min-height: 0; /* let the terminal shrink inside the flex column */
+  margin: 0;
+  overflow: auto;
   padding: 0.75rem;
   border: 0;
   border-radius: 0.375rem;
@@ -157,7 +178,25 @@
 
 .flasher pre.repl-term:focus-visible {
   outline: 2px solid var(--bs-primary, #30638e);
-  outline-offset: 2px;
+  outline-offset: -2px;
+}
+
+/* Fullscreen: the shell fills the viewport and stops being resizable (the drag
+   handle would fight the screen edge). :fullscreen matches whichever element
+   the Fullscreen API promoted — always .repl-shell here. A background is set
+   because the promoted element is composited over black, and the toolbar row
+   would otherwise sit on it. */
+.flasher .repl-shell:fullscreen {
+  height: 100%;
+  width: 100%;
+  resize: none;
+  padding: 0.75rem;
+  background: var(--bs-body-bg, #fff);
+}
+
+.flasher .repl-shell:fullscreen pre.repl-term {
+  border-radius: 0.375rem;
+  font-size: 0.95rem;
 }
 
 .flasher-diag summary {

--- a/static/flash/repl.js
+++ b/static/flash/repl.js
@@ -26,6 +26,8 @@ const el = {
   btnCtrlD: $("btn-repl-ctrld"),
   btnPaste: $("btn-repl-paste"),
   btnClear: $("btn-repl-clear"),
+  btnFullscreen: $("btn-repl-fullscreen"),
+  shell: $("repl-shell"),
 };
 
 // --------------------------------------------------------------------------
@@ -338,5 +340,38 @@ el.btnClear.addEventListener("click", () => {
   curPos = 0;
   render();
 });
+
+// --------------------------------------------------------------------------
+// Fullscreen
+// --------------------------------------------------------------------------
+
+// Not every browser that ships Web Serial also allows the Fullscreen API in
+// every context (an iframe without allowfullscreen, for one). Hide the button
+// rather than offer one that throws.
+if (!el.shell.requestFullscreen) {
+  el.btnFullscreen.classList.add("d-none");
+} else {
+  el.btnFullscreen.addEventListener("click", async () => {
+    try {
+      if (document.fullscreenElement === el.shell) {
+        await document.exitFullscreen();
+      } else {
+        await el.shell.requestFullscreen();
+      }
+    } catch {
+      // A rejected request (denied, or not user-activated) is not worth an
+      // error in the log; the button simply did nothing.
+    }
+  });
+
+  // Keep the button label and pressed state in step with reality, including
+  // when the user leaves fullscreen with Esc rather than the button.
+  document.addEventListener("fullscreenchange", () => {
+    const on = document.fullscreenElement === el.shell;
+    el.btnFullscreen.textContent = on ? "Exit fullscreen" : "Fullscreen";
+    el.btnFullscreen.setAttribute("aria-pressed", String(on));
+    if (on) term.focus();
+  });
+}
 
 setConnected(false);


### PR DESCRIPTION
The console was a fixed 22rem box — cramped for reading a traceback or watching live output. Now:

- **Drag the bottom-right corner** to resize it (CSS `resize: vertical`).
- **Fullscreen button** to fill the screen; Esc leaves it.

## How

Both work by wrapping the toolbar and terminal in a **shell** element. The shell carries the resize handle and is what the Fullscreen API promotes.

The key reason the toolbar moved *inside* the shell: whatever element goes fullscreen is the only thing visible, so if the toolbar stayed a sibling, Connect / Ctrl-C / Ctrl-D / Paste would vanish the moment you went fullscreen. Inside the shell they come along. The terminal flexes to fill whatever height is left.

## Robustness

- The button **hides itself** where the Fullscreen API is unavailable (some embedded contexts ship Web Serial but not fullscreen), rather than offering one that throws.
- A rejected request (denied, or not user-activated) is swallowed — the button just does nothing, no error in the log.
- The label and `aria-pressed` follow the *actual* fullscreen state via `fullscreenchange`, so leaving with **Esc** instead of the button keeps them in sync.

## Testing

```
  ok  fullscreen button shown when supported
  ok  starts in the enter state
  ok  clicking enters fullscreen on the shell
  ok  label flips to Exit
  ok  aria-pressed set
  ok  clicking again exits fullscreen
  ok  label flips back
  ok  aria-pressed cleared
  ok  external enter tracked
  ok  external exit (Esc) tracked
```

The rest of the REPL suite (output rendering, key mapping, paste mode, the clipboard button) still passes. Hugo builds clean, `reuse lint` green.

Resize itself is pure CSS, so there is nothing to unit-test there — it wants a real browser, which is the same visual check the whole flasher still needs on hardware.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
