### PR TITLE
Fix overflow on mobile

### DIFF
--- a/assets/scss/_variables_project.scss
+++ b/assets/scss/_variables_project.scss
@@ -5,11 +5,24 @@ Add styles or override variables from the theme here.
 */
 
 .navbar-brand .font-weight-bold {
-    visibility: hidden;
+    display: none;
 }
 
 .navbar-brand__name {
-    visibility: hidden;
+    display: none;
+}
+
+.list-group-horizontal {
+    overflow-x: scroll;
+}
+.list-group-horizontal::-webkit-scrollbar { 
+    display: none; /* Safari and Chrome */
+}
+
+.list-group-item {
+    position: relative;
+    display: flex;
+    flex-direction: column;
 }
 
 .homepage_badges {

--- a/layouts/_shortcodes/blocks/project.html
+++ b/layouts/_shortcodes/blocks/project.html
@@ -12,11 +12,11 @@
 </div>
 <div class="mb-0">
 <h3>Project progress</h3>
-<ul class="list-group list-group-horizontal d-flex justify-content-center">
-  <li class="list-group-item{{ if eq $phase "1" }} active{{ end }}"><h3>Phase 1</h3>Collecting ideas &amp; formulating requirements</li>
-  <li class="list-group-item{{ if eq $phase "2" }} active{{ end }}"><h3>Phase 2</h3>Research, prototyping &amp; working out finances</li>
-  <li class="list-group-item{{ if eq $phase "3" }} active{{ end }}"><h3>Phase 3</h3>Electronic design &amp; Firmware development</li>
-  <li class="list-group-item{{ if eq $phase "4" }} active{{ end }}"><h3>Phase 4</h3>Delivery</li>
+<ul class="list-group list-group-horizontal d-flex">
+  <li class="flex-grow-1 list-group-item{{ if eq $phase "1" }} active{{ end }}"><h3>Phase 1</h3>Collecting ideas &amp; formulating requirements</li>
+  <li class="flex-grow-1 list-group-item{{ if eq $phase "2" }} active{{ end }}"><h3>Phase 2</h3>Research, prototyping &amp; working out finances</li>
+  <li class="flex-grow-1 list-group-item{{ if eq $phase "3" }} active{{ end }}"><h3>Phase 3</h3>Electronic design &amp; Firmware development</li>
+  <li class="flex-grow-1 list-group-item{{ if eq $phase "4" }} active{{ end }}"><h3>Phase 4</h3>Delivery</li>
 </ul>
 </div>
 {{ with .Get "url" }}<p><a href="{{ . }}">{{ with $.Get "url_text" }}{{ . }}{{ else }}{{ T "ui_read_more" }}{{ end }}</a></p>{{ end }}


### PR DESCRIPTION
This PR fixes two causes of overflow on the homepage (logo and progress bars). The horizontal scroll made it a bit hard to read things on mobile. I've locally tested this fix on Firefox and Edge.

Before:

<img width="681" height="697" alt="Screenshot 2026-07-22 232927" src="https://github.com/user-attachments/assets/b6e7da94-81ed-4ee2-af01-4bea850f4180" />

After:

<img width="692" height="697" alt="Screenshot 2026-07-22 232938" src="https://github.com/user-attachments/assets/4ca00227-5fde-4ee3-809c-ec15332a09bf" />
