### PR TITLE
content(home): mark BornHack 2026 delivered and sold out

### DIFF
--- a/content/en/_index.md
+++ b/content/en/_index.md
@@ -40,12 +40,12 @@ Need help? Want to volunteer? <i class="fab fa-discord ml-2 "></i>
 
 {{% blocks/section color="white" %}}
 
-{{% blocks/project img="bornhack.png" phase="3" title="**Bornhack** 2026" %}}
-In collaboration with [**Thomas Flummer**](https://thomasflummer.com/) we've started work on a badge for [**Bornhack**](https://bornhack.dk) 2026.
+{{% blocks/project img="bornhack.png" phase="4" title="**Bornhack** 2026" %}}
+In collaboration with [**Thomas Flummer**](https://thomasflummer.com/) we built the **Cyber Ægg** badge for [**Bornhack**](https://bornhack.dk) 2026 — delivered and **sold out**!
 
 BornHack is a 7 day outdoor tent camp where hackers, makers and people with an interest in technology or security come together to celebrate technology, socialise, learn and have fun.
 
-More information about the badge will soon be published [here](/docs/badges/bornhack-2026/).
+All the documentation — hardware, firmware, and an in-browser [flasher](/docs/badges/bornhack-2026/flash/) — is [here](/docs/badges/bornhack-2026/).
 {{% /blocks/project %}}
 
 {{% /blocks/section %}}


### PR DESCRIPTION
The Cyber Ægg has been **delivered and sold out** 🎉 — the front-page project block was stale.

### Changes (`content/en/_index.md`)
- **Phase 3 → 4** (Delivery) — the progress bar now highlights the final stage.
- Copy moved to past tense: "we built the **Cyber Ægg** badge … delivered and **sold out**!"
- Replaced the "will soon be published" note with links to the live [documentation](/docs/badges/bornhack-2026/) and the in-browser [flasher](/docs/badges/bornhack-2026/flash/).

### Verification
- `hugo --gc --minify` clean; rendered `index.html` confirmed showing Phase 4 active and the "sold out" copy.
- `reuse lint` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
