### PR TITLE
fix(bornhack): correct DFU power-cycle and drop the USB/Bluetooth claim

### DIFF
--- a/content/en/docs/Badges/Bornhack 2026/circuitpython/_index.md
+++ b/content/en/docs/Badges/Bornhack 2026/circuitpython/_index.md
@@ -29,10 +29,11 @@ and settings survive in flash.
    Windows).
 3. Copy the library and an example onto the drive, as below.
 
-{{% alert title="Reset rather than reboot from the flasher" color="info" %}}
-After flashing, restart the badge with a **reset**, not by asking the tool to
-reboot it. The battery keeps the badge powered when USB is unplugged, so a reset
-is the reliable way to hand off to the new firmware.
+{{% alert title="Power-cycle rather than reboot from the flasher" color="info" %}}
+After flashing, restart the badge with the **power switch** (slide it off, then
+back on), not by asking the tool to reboot it. The battery keeps the badge
+powered when USB is unplugged, so a clean power-cycle is the reliable way to
+hand off to the new firmware.
 {{% /alert %}}
 
 ## Install the libraries

--- a/content/en/docs/Badges/Bornhack 2026/clock/_index.md
+++ b/content/en/docs/Badges/Bornhack 2026/clock/_index.md
@@ -82,7 +82,7 @@ The badge imports events at boot from a file named **`ALARMS.ICS`** in the root 
 2. Open the drive labelled `CYBR<4 hex>`.
 3. Drop your `.ics` file in the root, renamed to `ALARMS.ICS`.
 4. Eject the drive.
-5. Reboot the badge (unplug USB or reset).
+5. Reboot the badge — slide the power switch off, then back on.
 
 You can use the official BornHack programme `.ics` straight from <https://bornhack.dk/>.
 

--- a/content/en/docs/Badges/Bornhack 2026/faq/_index.md
+++ b/content/en/docs/Badges/Bornhack 2026/faq/_index.md
@@ -22,7 +22,7 @@ The cell measured below 3.0 V at power-on, so the firmware halts to protect it. 
 Expected — there is no battery-backed RTC. Pair over Bluetooth with the MeshCore app once per boot, or wait until you are near a synced mesh repeater. Note that on-air time is only accepted from a **trusted source** — a signature-verified repeater / companion advert or a channel you hold the key for. A crowd of other badges won't set your clock; a phone pairing always will.
 
 **Bluetooth isn't visible / I can't pair.**
-Two things to check: USB is plugged in (Bluetooth is disabled whenever USB is connected — unplug), or Bluetooth was switched off in **Main → Settings → Bluetooth** (the toggle persists across reboots; set it back to `BLE: ON`).
+Check that Bluetooth wasn't switched off in **Main → Settings → Bluetooth** — the toggle persists across reboots, so set it back to `BLE: ON`.
 
 **My alarm never fired.**
 The clock hasn't been set yet this boot — alarms only fire once the time is known. If the clock *is* set, check the alarm's **Days** field — `None` never fires, and a Weekdays / Weekends / Custom mask only fires on matching days (the header bell shows for any enabled alarm regardless of its day mask).

--- a/content/en/docs/Badges/Bornhack 2026/flash/_index.md
+++ b/content/en/docs/Badges/Bornhack 2026/flash/_index.md
@@ -25,8 +25,9 @@ otherwise the device appears in the chooser but fails to open.
 ## If something goes wrong
 
 **The device chooser is empty.** The badge is not in DFU mode. Put it in the
-bootloader first (for the Cyber Ægg: unplug, hold **Execute**, plug back in —
-the LED blinks red), then click *Connect* again.
+bootloader first (for the Cyber Ægg: slide the power switch off, then back on
+while holding **Execute** — the LED blinks red), then click *Connect* again.
+The battery keeps the badge running, so unplugging USB does not restart it.
 
 **It connects but says "application firmware (CDC)".** Same cause: you reached
 the running firmware rather than the bootloader. Power-cycle into DFU mode.

--- a/content/en/docs/Badges/Bornhack 2026/getting-started/_index.md
+++ b/content/en/docs/Badges/Bornhack 2026/getting-started/_index.md
@@ -53,7 +53,7 @@ The interface is a carousel — **Left** / **Right** cycles through the top-leve
 
 The badge speaks the [MeshCore](https://meshcore.io/) companion protocol over Bluetooth Low Energy. Install the **MeshCore** app on Android / iOS, or open <https://app.meshcore.nz/> in a browser that supports Web Bluetooth (Chrome / Edge on desktop or Android).
 
-1. Power the badge with USB **unplugged** — Bluetooth is disabled while USB is connected.
+1. Make sure Bluetooth is on — **Main → Settings → Bluetooth** should read `BLE: ON`.
 2. In the app, scan for devices. Your badge advertises as **`Cyber Ægg XXYY`**, where `XXYY` is four hex characters unique to your badge.
 3. The phone shows a passkey prompt and the badge shows a 6-digit passkey on its display. Type that number into the phone.
 4. Once bonded, the app can set the clock, manage contacts, send and receive mesh messages, change the LoRa preset and more.
@@ -69,7 +69,7 @@ Set your timezone once under **Main → Settings → Timezone** — that setting
 
 ## Charging
 
-Plug any USB-C cable into the badge to charge it. Charge state is shown on the on-screen battery icon (there is no dedicated charge LED). Remember that Bluetooth is off while USB is connected, so unplug the badge when you want to pair.
+Plug any USB-C cable into the badge to charge it. Charge state is shown on the on-screen battery icon (there is no dedicated charge LED).
 
 Two things that look like faults but aren't: the charge bolt disappearing while USB is still plugged means charging is **complete** (it returns by itself if the cell drains), and the battery icon can lag up to a minute behind reality — it is only re-sampled every 60 seconds.
 
@@ -94,7 +94,7 @@ Reboot the badge after copying files (re-plug USB) for the changes to take effec
 
 The easiest route is the [Flash page](../flash/): it writes the firmware and the badge's asset files straight from a Chromium-family browser, with no toolchain to install.
 
-To do it by hand, hold **Execute** while plugging in USB to enter the bootloader (DFU) mode — the LED blinks red. You can then flash a new firmware image with [`dfu-util`](https://dfu-util.sourceforge.net/):
+To do it by hand, slide the power switch off and then back on while holding **Execute** to enter the bootloader (DFU) mode — the LED blinks red. (The battery keeps the badge running, so unplugging USB will not restart it.) You can then flash a new firmware image with [`dfu-util`](https://dfu-util.sourceforge.net/):
 
 ```
 dfu-util -d 1915:521f -D cyber-aegg.bin

--- a/content/en/docs/Badges/Bornhack 2026/hardware/_index.md
+++ b/content/en/docs/Badges/Bornhack 2026/hardware/_index.md
@@ -82,4 +82,4 @@ The firmware can also drive an optional **Nicolai-Electronics I²C keyboard** on
 
 ## Power
 
-The badge is powered by a LiPo battery and charged over USB-C. Bluetooth is disabled while USB is connected to keep the charging path simple, so unplug the badge when you want to pair with the MeshCore app.
+The badge is powered by a LiPo battery and charged over USB-C.

--- a/content/en/docs/Badges/Bornhack 2026/quick-reference/_index.md
+++ b/content/en/docs/Badges/Bornhack 2026/quick-reference/_index.md
@@ -50,7 +50,7 @@ Left / Right cycles through them:
 
 ## Power-on combos
 
-Hold these while connecting USB / resetting:
+Hold these while powering on — slide the power switch off, then back on (the battery keeps the badge running, so unplugging USB will not restart it):
 
 | Hold | Result |
 | ---- | ------ |
@@ -85,4 +85,4 @@ Bootloader LEDs in DFU: red blink (idle) → solid blue (flashing) → solid gre
 
 ## Charging
 
-USB-C in any port charges the badge. There is no separate charge LED — the battery icon on the watch / status bar shows the level. Unplug USB to re-enable Bluetooth pairing.
+USB-C in any port charges the badge. There is no separate charge LED — the battery icon on the watch / status bar shows the level.

--- a/data/firmwares.toml
+++ b/data/firmwares.toml
@@ -23,7 +23,7 @@ name = "BornHack 2026 — Cyber Ægg"
 docsUrl = "/docs/badges/bornhack-2026/"
 # Shown when a connected badge turns out to be running the app, not the
 # bootloader. Rendered as HTML.
-dfuHint = "Unplug the badge, hold <strong>Execute</strong>, and plug it back in — the LED blinks red in DFU mode."
+dfuHint = "Slide the power switch off, then back on while holding <strong>Execute</strong> — the LED blinks red in DFU mode. (The battery keeps it running, so unplugging USB will not restart it.)"
 # One nRF52840 flash page. Source: bootloader/src/dfu.rs.
 blockSize = 4096
 # Bootloader identity in DFU mode (bootloader/src/dfu.rs).


### PR DESCRIPTION
Two corrections from the delivered hardware.

### DFU entry — power switch, not USB unplug
The badge runs on its battery and its reset is buried behind the 3D-printed back, so "unplug the badge and plug it back in" never actually restarts it. Replaced with the reliable move — **slide the power switch off, then back on while holding Execute** — and added a note that unplugging USB won't power-cycle it.

Fixed in: the flasher's DFU hint (`data/firmwares.toml`), the [flash](/docs/badges/bornhack-2026/flash/) and getting-started firmware-update steps, the quick-reference power-on combos, the clock alarm-import reboot step, and the CircuitPython power-cycle alert.

### Bluetooth ↔ USB — hallucinated claim removed
"Bluetooth is disabled while USB is connected" was **false** — BLE works with USB attached. Removed the claim and the "unplug to pair" guidance from getting-started, hardware, quick-reference and the FAQ; the pairing troubleshooting now just checks the `BLE: ON` toggle.

### Verification
- `hugo --gc --minify` clean; `reuse lint` green.
- Grep confirms no remaining "Bluetooth is disabled / off while USB" or "plug it back in" DFU wording.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
