### PR TITLE
docs(bornhack): name the ON/OFF switch and give its location

### DIFF
--- a/content/en/docs/Badges/Bornhack 2026/circuitpython/_index.md
+++ b/content/en/docs/Badges/Bornhack 2026/circuitpython/_index.md
@@ -30,8 +30,8 @@ and settings survive in flash.
 3. Copy the library and an example onto the drive, as below.
 
 {{% alert title="Power-cycle rather than reboot from the flasher" color="info" %}}
-After flashing, restart the badge with the **power switch** (slide it off, then
-back on), not by asking the tool to reboot it. The battery keeps the badge
+After flashing, restart the badge with the **ON/OFF** switch — top-left on the
+front — (slide it off, then back on), not by asking the tool to reboot it. The battery keeps the badge
 powered when USB is unplugged, so a clean power-cycle is the reliable way to
 hand off to the new firmware.
 {{% /alert %}}

--- a/content/en/docs/Badges/Bornhack 2026/clock/_index.md
+++ b/content/en/docs/Badges/Bornhack 2026/clock/_index.md
@@ -82,7 +82,7 @@ The badge imports events at boot from a file named **`ALARMS.ICS`** in the root 
 2. Open the drive labelled `CYBR<4 hex>`.
 3. Drop your `.ics` file in the root, renamed to `ALARMS.ICS`.
 4. Eject the drive.
-5. Reboot the badge — slide the power switch off, then back on.
+5. Reboot the badge — slide the **ON/OFF** switch (top-left on the front) off, then back on.
 
 You can use the official BornHack programme `.ics` straight from <https://bornhack.dk/>.
 

--- a/content/en/docs/Badges/Bornhack 2026/flash/_index.md
+++ b/content/en/docs/Badges/Bornhack 2026/flash/_index.md
@@ -25,9 +25,10 @@ otherwise the device appears in the chooser but fails to open.
 ## If something goes wrong
 
 **The device chooser is empty.** The badge is not in DFU mode. Put it in the
-bootloader first (for the Cyber Ægg: slide the power switch off, then back on
-while holding **Execute** — the LED blinks red), then click *Connect* again.
-The battery keeps the badge running, so unplugging USB does not restart it.
+bootloader first (for the Cyber Ægg: slide the **ON/OFF** switch — top-left on
+the front of the badge — off, then back on while holding **Execute**, and the
+LED blinks red), then click *Connect* again. The battery keeps the badge
+running, so unplugging USB does not restart it.
 
 **It connects but says "application firmware (CDC)".** Same cause: you reached
 the running firmware rather than the bootloader. Power-cycle into DFU mode.

--- a/content/en/docs/Badges/Bornhack 2026/getting-started/_index.md
+++ b/content/en/docs/Badges/Bornhack 2026/getting-started/_index.md
@@ -94,7 +94,7 @@ Reboot the badge after copying files (re-plug USB) for the changes to take effec
 
 The easiest route is the [Flash page](../flash/): it writes the firmware and the badge's asset files straight from a Chromium-family browser, with no toolchain to install.
 
-To do it by hand, slide the power switch off and then back on while holding **Execute** to enter the bootloader (DFU) mode — the LED blinks red. (The battery keeps the badge running, so unplugging USB will not restart it.) You can then flash a new firmware image with [`dfu-util`](https://dfu-util.sourceforge.net/):
+To do it by hand, slide the **ON/OFF** switch (top-left on the front of the badge) off and then back on while holding **Execute** to enter the bootloader (DFU) mode — the LED blinks red. (The battery keeps the badge running, so unplugging USB will not restart it.) You can then flash a new firmware image with [`dfu-util`](https://dfu-util.sourceforge.net/):
 
 ```
 dfu-util -d 1915:521f -D cyber-aegg.bin

--- a/content/en/docs/Badges/Bornhack 2026/hardware/_index.md
+++ b/content/en/docs/Badges/Bornhack 2026/hardware/_index.md
@@ -24,7 +24,7 @@ At the time of writing the design is still at prototype stage. Some of the RF ci
 | NFC | nRF52840 NFC tag PHY + on-PCB coil | — |
 | Input | 5-way joystick + `Execute` / `Cancel` buttons | GPIO |
 | Feedback | RGB LED, piezo buzzer | GPIO / PWM |
-| Power | Li-ion battery, USB-C for power and data | — |
+| Power | Li-ion battery, USB-C for power and data, `ON/OFF` slide switch | — |
 
 {{% alert title="Expansion connector pinout" color="danger" %}}
 There is a QWIIC like I2C expansion connector on the board. Be aware that we made a small design mistake: the 3.3v and GND signals have been swapped around. Make sure to use a modified cable before connecting any QWIIC peripherals.
@@ -82,4 +82,4 @@ The firmware can also drive an optional **Nicolai-Electronics I²C keyboard** on
 
 ## Power
 
-The badge is powered by a LiPo battery and charged over USB-C.
+The badge is powered by a LiPo battery and charged over USB-C. An `ON/OFF` slide switch (top-left on the front) cuts battery power — sliding it off and back on is how you power-cycle the badge, since the battery otherwise keeps it running even with USB unplugged. Hold **Execute** while switching on to enter DFU mode for flashing.

--- a/content/en/docs/Badges/Bornhack 2026/quick-reference/_index.md
+++ b/content/en/docs/Badges/Bornhack 2026/quick-reference/_index.md
@@ -50,7 +50,7 @@ Left / Right cycles through them:
 
 ## Power-on combos
 
-Hold these while powering on — slide the power switch off, then back on (the battery keeps the badge running, so unplugging USB will not restart it):
+Hold these while powering on — slide the **ON/OFF** switch (top-left on the front) off, then back on (the battery keeps the badge running, so unplugging USB will not restart it):
 
 | Hold | Result |
 | ---- | ------ |

--- a/data/firmwares.toml
+++ b/data/firmwares.toml
@@ -23,7 +23,7 @@ name = "BornHack 2026 — Cyber Ægg"
 docsUrl = "/docs/badges/bornhack-2026/"
 # Shown when a connected badge turns out to be running the app, not the
 # bootloader. Rendered as HTML.
-dfuHint = "Slide the power switch off, then back on while holding <strong>Execute</strong> — the LED blinks red in DFU mode. (The battery keeps it running, so unplugging USB will not restart it.)"
+dfuHint = "Slide the <strong>ON/OFF</strong> switch (top-left on the front) off, then back on while holding <strong>Execute</strong> — the LED blinks red in DFU mode. (The battery keeps it running, so unplugging USB will not restart it.)"
 # One nRF52840 flash page. Source: bootloader/src/dfu.rs.
 blockSize = 4096
 # Bootloader identity in DFU mode (bootloader/src/dfu.rs).


### PR DESCRIPTION
The badge-front render shows a silkscreened **ON/OFF** slide switch at the top-left of the board — the one you power-cycle to enter DFU. The docs called it only "the power switch", which is hard to locate on a busy egg-shaped PCB.

### Changes
- Named it **ON/OFF** and gave its location (top-left on the front) everywhere the power-cycle is mentioned: the flasher DFU hint (`data/firmwares.toml`), the flash and getting-started firmware-update steps, the quick-reference power-on combos, the clock reboot step, and the CircuitPython alert.
- Documented the switch itself on the **hardware** page — added it to the Power row of the specs table and a sentence in the Power section (it wasn't listed anywhere before).

### Verification
- `hugo --gc --minify` clean; `reuse lint` green.
- Grep confirms no bare "power switch" references remain — all now name ON/OFF.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
