### PR TITLE
fix(bornhack): correct the 'pet and settings survive' claim

### DIFF
--- a/content/en/docs/Badges/Bornhack 2026/circuitpython/_index.md
+++ b/content/en/docs/Badges/Bornhack 2026/circuitpython/_index.md
@@ -13,11 +13,15 @@ moment you save.
 The display, buttons, joystick, LEDs, buzzer, battery, LoRa radio and NFC are
 all reachable from ordinary CircuitPython modules.
 
-{{% alert title="It replaces the badge firmware" color="warning" %}}
+{{% alert title="It replaces the firmware and wipes your saved data" color="warning" %}}
 CircuitPython is a separate image, not an app inside the normal firmware. While
 it is installed there is no BornPets, mesh or clock — flash the standard
-firmware again from the [Flash page](../flash/) to get the badge back. Your pet
-and settings survive in flash.
+firmware again from the [Flash page](../flash/) to get the badge back.
+
+The CIRCUITPY drive lives on the same QSPI flash that holds your pet, settings
+(the KV store) and the badge's asset files, so switching to CircuitPython
+overwrites them. Your pet and settings are lost, and when you flash a normal
+firmware back you will need to re-install its assets before the sprites return.
 {{% /alert %}}
 
 ## Install it

--- a/content/en/docs/Badges/Bornhack 2026/doom/_index.md
+++ b/content/en/docs/Badges/Bornhack 2026/doom/_index.md
@@ -11,11 +11,17 @@ level's music picked out on the piezo buzzer.
 
 It is a slideshow, and it is genuinely playable.
 
-{{% alert title="DOOM replaces the badge firmware" color="warning" %}}
+{{% alert title="DOOM replaces the firmware and wipes your saved data" color="warning" %}}
 This is a separate firmware image, not an app inside the normal one. While DOOM
 is installed there is no BornPets, no mesh, no clock — flash the standard
-firmware again from the [Flash page](../flash/) to get the badge back. Nothing
-is lost by switching; your pet and settings live in flash and survive.
+firmware again from the [Flash page](../flash/) to get the badge back.
+
+Switching to DOOM is **destructive**. The WAD fills nearly all of the badge's
+2 MB QSPI flash, and that same chip holds your pet and settings (the KV store)
+and the badge's asset files — uploading the WAD overwrites them. So your pet and
+settings are lost, and when you flash a normal firmware back you will need to
+re-install its assets from the [Flash page](../flash/) before the sprites show
+up again.
 {{% /alert %}}
 
 ## How to install it

--- a/data/firmwares.toml
+++ b/data/firmwares.toml
@@ -82,7 +82,7 @@ appPid = "0x0001"
   # from main @ dbad849 (2026-07-21). Links at 0x10000 like the others.
   file = "/firmware/cyber-aegg/cyber-aegg-doom.bin"
   sha256 = "c470cc78b6bf70348c0cd3f0f56e5c9e729867d16c91bfd8d06f18e36d8a4161"
-  notes = "DOOM E1M1, rendered on the e-paper panel at a couple of frames per second, with the level's music on the buzzer. Flashing this is only half the job: the game data is far too big for the USB drive, so you have to upload a WAD separately before DOOM will start. It also replaces the badge firmware — no BornPets, mesh or clock until you flash one of those back, though your pet and settings survive in flash."
+  notes = "DOOM E1M1, rendered on the e-paper panel at a couple of frames per second, with the level's music on the buzzer. Flashing this is only half the job: the game data is far too big for the USB drive, so you have to upload a WAD separately before DOOM will start. It also replaces the badge firmware — no BornPets, mesh or clock until you flash one of those back. Uploading the WAD fills the QSPI flash that also holds your pet, settings and asset files, so those are wiped: switching back means re-installing the assets, and the pet starts over."
   # Rendered as a link under the notes, and in place of the asset step.
   moreUrl = "../doom/"
   moreLabel = "How to upload the WAD →"


### PR DESCRIPTION
The DOOM and CircuitPython pages both claimed switching image lost nothing — *"your pet and settings survive in flash"*. That's **false**.

The pet, settings (the KV store) and the badge's asset files all live in the 2 MB QSPI flash. The DOOM WAD fills nearly all of that chip, and CircuitPython reformats it as the CIRCUITPY drive — so installing either image **overwrites** your saved data. The pet and settings are lost, and the assets have to be re-installed after flashing a normal firmware back.

### Changes
- **DOOM page** — rewrote the warning alert: switching is destructive, WAD overwrites KV store + assets.
- **CircuitPython page** — same correction: CIRCUITPY lives on that QSPI, so it wipes pet/settings/assets.
- **`data/firmwares.toml`** — fixed the DOOM firmware notes (also serialised into every flash page's JSON).

### Verification
- `hugo --gc --minify` clean; `reuse lint` green.
- Grep confirms no "settings survive / nothing is lost / settings live in flash" claims remain; corrected note confirmed in the built flash page JSON.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
