### PR TITLE
content(home): move HackerHotel 2027 to phase 2

### DIFF
--- a/content/en/_index.md
+++ b/content/en/_index.md
@@ -52,7 +52,7 @@ All the documentation — hardware, firmware, and an in-browser [flasher](/docs/
 
 {{% blocks/section color="black" %}}
 
-{{% blocks/project img="hackerhotel.png" phase="1" title="**HackerHotel** 2027" %}}
+{{% blocks/project img="hackerhotel.png" phase="2" title="**HackerHotel** 2027" %}}
 
 With **LoRa**, a **keyboard**, a **big screen** and the powerhouse **ESP32-P4** microcontroller you can guess how big our ambitions are! Our next challenge is fitting it all into the **budget**.
 


### PR DESCRIPTION
The HackerHotel 2027 block on the front page still shows **Phase 1 — collecting
ideas & formulating requirements**. The work has moved on, so this flips it to
**Phase 2 — research, prototyping & working out finances**.

One attribute changes, `phase="1"` → `phase="2"` in `content/en/_index.md`. The
block's copy already describes phase 2 work ("Our next challenge is fitting it
all into the budget"), so no text needed rewriting. The Bornhack block stays on
phase 4.

Built output checked: the HackerHotel tracker marks Phase 2 active, the
Bornhack one still marks Phase 4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0142DuVFXpWnjeQhZzT3N3nC
