### PR TITLE
docs(hackerhotel-2023): describe the badge and link its repositories

### DIFF
--- a/content/en/docs/Badges/Hackerhotel 2023/_index.md
+++ b/content/en/docs/Badges/Hackerhotel 2023/_index.md
@@ -4,6 +4,57 @@ nodateline: true
 weight: -2023
 ---
 
+The Hackerhotel 2023 badge, the **Anesidora Mk1**, is a puzzle badge built around
+a **RP2040** microcontroller. The board is artwork first: the copper and the
+soldermask draw a cracked stone tablet in lapis blue and gold, in the style of an
+ancient grave marker, and the electronics sit in and around it.
+
+The badge was the key to the puzzle hunt at the event. Clues were hidden in
+binary on the lanyards and on markers around the hotel, and the badge itself
+served a text adventure over its USB serial port. Attendees who solved
+everything received a physical amulet.
+
+## Hardware
+
+ - RP2040 microcontroller
+ - A row of buttons and LEDs along the bottom of the board, laid out as the data
+   and address lines of a small computer
+ - USB-C for power, serial and firmware updates
+ - CR2032 coin cell for use away from a cable, selected with the BAT/USB switch
+   on the top edge
+ - Artwork in the copper and soldermask layers of the PCB itself
+
+## Firmware
+
+The firmware is written in MicroPython. Updates ship as a `.uf2` file, which the
+RP2040 bootloader takes without any tools:
+
+1. Download the `.uf2` from the
+   [firmware update repository](https://github.com/AnesidoraCorporation/hh2023firmwareupdate).
+2. Set the switch on the top of the badge to **USB** and connect it to your
+   computer.
+3. Hold **BOOTSEL**, press **RESET**, then release both.
+4. Copy the `.uf2` file to the `RPI-RP2` drive that appears.
+5. Wait for the copy to finish, then press **RESET**.
+
+If the badge does not run on battery, the contacts of the battery clip are
+usually the cause. The
+[documentation repository](https://github.com/AnesidoraCorporation/hh2023documentation)
+explains how to bend them back.
+
+## Repositories
+
+The badge was developed under the Anesidora Corporation organisation on GitHub:
+
+ - [hh2023hardware](https://github.com/AnesidoraCorporation/hh2023hardware) — KiCad design files
+ - [hh2023firmware](https://github.com/AnesidoraCorporation/hh2023firmware) — the badge firmware
+ - [hh2023firmwareupdate](https://github.com/AnesidoraCorporation/hh2023firmwareupdate) — released `.uf2` updates
+ - [hh2023documentation](https://github.com/AnesidoraCorporation/hh2023documentation) — visitor instructions, location markers and an FAQ
+
+## More reading
+
+ - [Hacker Hotel 2023 Had A Very Cool Badge](https://hackaday.com/2023/03/10/hacker-hotel-2023-had-a-very-cool-badge/) on Hackaday
+
 ## The team
 
  - Pim: Team lead, hardware and software development


### PR DESCRIPTION
Closes #121.

The Hackerhotel 2023 page held three credits and nothing else — no description
of the badge, no repository links.

## What the page says now

- **What the badge is.** The Anesidora Mk1: an RP2040 puzzle badge whose PCB
  artwork is a cracked stone tablet in lapis blue and gold. It drove the puzzle
  hunt at the event, with binary clues on the lanyards and markers, and served
  a text adventure over its USB serial port. Solvers got a physical amulet.
- **Hardware list** — RP2040, the row of buttons and LEDs laid out as the data
  and address lines of a small computer, USB-C, CR2032 with the BAT/USB switch,
  and the artwork in the copper and soldermask layers.
- **Firmware and updates** — MicroPython, and the `.uf2` procedure taken from
  the badge's own update repository (BOOTSEL + RESET, copy to `RPI-RP2`), plus
  a pointer to the battery-clip fix in the documentation repository's FAQ.
- **Repository links** — all four under the Anesidora Corporation org:
  [hardware](https://github.com/AnesidoraCorporation/hh2023hardware),
  [firmware](https://github.com/AnesidoraCorporation/hh2023firmware),
  [firmware updates](https://github.com/AnesidoraCorporation/hh2023firmwareupdate),
  [documentation](https://github.com/AnesidoraCorporation/hh2023documentation).
- **The Hackaday article** the issue asked for.

The team credits are unchanged.

Sources are those four repositories and the Hackaday write-up. The issue linked
a Reddit comment for the repository URLs; Reddit blocks automated fetches here,
so the org was found through the Hackaday article and each repository confirmed
directly on GitHub.

## Checks

- `hugo --gc --minify` — clean.
- Every link added returns 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0142DuVFXpWnjeQhZzT3N3nC
