### PR TITLE
fix(style): stop pages scrolling sideways on narrow screens

### DIFF
--- a/assets/scss/_variables_project.scss
+++ b/assets/scss/_variables_project.scss
@@ -4,6 +4,25 @@ Add styles or override variables from the theme here.
 
 */
 
+/* A long URL used as link text, or a code-like heading, is one unbreakable
+   word. Without this the whole page scrolls sideways on a phone. */
+.td-content {
+    overflow-wrap: break-word;
+}
+
+/* The logo declares its size in millimetres, about 302px, which is wider than
+   the smallest phones once the navbar padding counts. The calc only bites
+   below ~340px, so the logo keeps its size everywhere else. */
+.navbar-brand svg {
+    max-width: calc(100vw - 2.5rem);
+}
+
+/* Swagger UI lays itself out wider than the content column on small screens.
+   Give the widget its own scroll area rather than scrolling the page. */
+#docsy_swagger_ui {
+    overflow-x: auto;
+}
+
 .navbar-brand .font-weight-bold {
     display: none;
 }


### PR DESCRIPTION
Refs #119.

The screenshot in #119 is the front page: the 80s stamp logo pushed the cover
wider than the phone. That part was fixed in `2060291` and `3869337`. Rather
than close the issue on that alone, I measured the whole site.

## Method

Headless Chrome over CDP, every page in `sitemap.xml` (177), at 320, 375, 414
and 768 px, comparing `documentElement.scrollWidth` with `clientWidth` and
listing the elements that stick out.

**Before:** 177 pages overflowed at 320 px, 7 at 375 px, 4 at 414 px, 1 at
768 px. Worst case `/docs/badges/campzone-2019/`, 243 px too wide on a 320 px
screen and still 54 px too wide at 768 px.

## Causes and fixes

Three rules in `assets/scss/_variables_project.scss`:

1. **Unbreakable words.** A long URL used as link text, or a heading holding a
   line of code, cannot wrap. That is what widened campzone-2019, the
   Hackerhotel 2020 PuTTY page, the Hackerhotel 2024 and MCH2022
   software-development pages and `/contact/`.
   → `.td-content { overflow-wrap: break-word; }`. Code blocks are unaffected:
   `pre` does not wrap, so there is nothing to break there.
2. **The brand logo.** `assets/icons/logo.svg` declares `width="80mm"`, about
   302 px, and the navbar margins add 20 px — wider than a 320 px screen, worth
   1–2 px of scroll on every page.
   → `max-width: calc(100vw - 2.5rem)` on the navbar svg. That only bites below
   roughly 340 px, so the logo is unchanged on every other screen (checked at
   1280 px).
3. **Swagger UI** on `/docs/hatchery/api/` and `/docs/hatchery/api_mch2022/`
   lays itself out wider than the content column.
   → `#docsy_swagger_ui { overflow-x: auto; }`, so the widget scrolls instead
   of the page.

## Result

The same sweep after the change: **177 pages × 4 widths, 0 overflowing.**

Also checked visually at 320 and 375 px (front page, campzone-2019, the PuTTY
page) and at 1280 px for the desktop layout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0142DuVFXpWnjeQhZzT3N3nC
