### PR TITLE
docs(mch2022): document addressable LEDs on an SAO

### DIFF
--- a/content/en/docs/Badges/MCH2022/software-development/api/ws2812.md
+++ b/content/en/docs/Badges/MCH2022/software-development/api/ws2812.md
@@ -91,7 +91,7 @@ lowest byte is the white channel, which only 32-bit RGBW LEDs use.
 Nothing lights up until `rp2040_ws2812_trigger` runs, so you can stage a
 whole frame and show it at once.
 
-### A worked example
+### Example app
 
 [`mch2022-tilde-ws2812-sao-test-app`](https://github.com/renzenicolai/mch2022-tilde-ws2812-sao-test-app)
 by Renze Nicolai is the template app with exactly this added: it sets up

--- a/content/en/docs/Badges/MCH2022/software-development/api/ws2812.md
+++ b/content/en/docs/Badges/MCH2022/software-development/api/ws2812.md
@@ -51,3 +51,57 @@ A minimal example to set all LEDs to red:
 To animate, change the array values and repeat `ws2812_send_data`
 in regular intervals.
 
+## Addressable LEDs on an SAO
+
+The LEDs on an add-on are a different story: they hang off the SAO
+connector, and that pin belongs to the RP2040, not to the ESP32. So the
+`ws2812` component above does not reach them. Instead you ask the RP2040
+to shift the data out for you, over the I2C link the badge already uses
+for the buttons.
+
+The RP2040 drives the WS2812 chain on `SAO_IO0`, which is pin 5 of the
+[SAO connector](/docs/standards/sao/) — the pin the standard reserves as
+the data line for addressable LEDs. It can hold up to **10** LEDs. The
+API lives in the [`mch2022-rp2040`
+component](https://github.com/badgeteam/esp32-component-mch2022-rp2040)
+that the template app already includes, and needs RP2040 firmware
+version 9 or newer.
+
+Set it up once:
+
+```c
+RP2040* rp2040 = get_rp2040();
+rp2040_set_gpio_dir(rp2040, 0, true);    // SAO IO0 becomes an output
+rp2040_set_ws2812_mode(rp2040, 1);       // 1 = enabled, 24-bit RGB
+rp2040_set_ws2812_length(rp2040, 5);     // number of LEDs on the add-on
+```
+
+Then write the LEDs and push the buffer out:
+
+```c
+for (uint8_t i = 0; i < 5; i++) {
+    rp2040_set_ws2812_data(rp2040, i, 0x00FF0000);   // red
+}
+rp2040_ws2812_trigger(rp2040);
+```
+
+Each value is one 32-bit word, and WS2812 LEDs take their colors in GRB
+order: green in bits 31-24, red in bits 23-16, blue in bits 15-8. The
+lowest byte is the white channel, which only 32-bit RGBW LEDs use.
+Nothing lights up until `rp2040_ws2812_trigger` runs, so you can stage a
+whole frame and show it at once.
+
+### A worked example
+
+[`mch2022-tilde-ws2812-sao-test-app`](https://github.com/renzenicolai/mch2022-tilde-ws2812-sao-test-app)
+by Renze Nicolai is the template app with exactly this added: it sets up
+the five LEDs of the tilde add-on, then fades each color up and down,
+first across all five LEDs together and then one LED at a time. It is a
+short read and a good starting point for your own add-on.
+
+{{% alert title="RGBW mode does not work yet" color="warning" %}}
+Mode `2` is meant to select 32-bit RGBW output, but the RP2040 firmware
+falls through from that case straight into disabling the output, so the
+LEDs go dark instead. Use mode `1` until that is fixed upstream.
+{{% /alert %}}
+


### PR DESCRIPTION
Closes #91.

The issue asked for the tilde SAO test app as an example. It needed a
place to live, so this adds the missing half of the WS2812 page.

## The gap

The page covered only the badge's own five kite LEDs, driven by the ESP32
through the `ws2812` component. LEDs on an add-on take a different path:
the chain hangs off `SAO_IO0` (pin 5 of the SAO connector), which belongs
to the **RP2040**, so that component cannot reach them. The ESP32 asks the
RP2040 to shift the data out, over the same I2C link it uses for buttons.

## What the page says now

- The set-up sequence — `rp2040_set_gpio_dir`, `rp2040_set_ws2812_mode`,
  `rp2040_set_ws2812_length` — and the write-then-`rp2040_ws2812_trigger`
  pattern.
- The word layout: GRB, green in bits 31-24, red 23-16, blue 15-8, low
  byte for the white channel of RGBW parts.
- The limits: 10 LEDs maximum, RP2040 firmware version 9 or newer.
- [`renzenicolai/mch2022-tilde-ws2812-sao-test-app`](https://github.com/renzenicolai/mch2022-tilde-ws2812-sao-test-app)
  as the worked example, with a sentence on what it actually does.
- A warning that mode `2` (RGBW) does not work: the RP2040 firmware's
  switch falls through from `case 0x02` into `ws2812_disable()`, so the
  LEDs go dark. Worth a one-line fix upstream in
  `mch2022-firmware-rp2040/i2c_peripheral.c`.

Sources: `esp32-component-mch2022-rp2040` (`rp2040.c`, `include/rp2040.h`),
`mch2022-firmware-rp2040` (`hardware.h`, `ws2812.c`, `i2c_peripheral.c`)
and the example app.

## Checks

`hugo --gc --minify` clean; both external links return 200; the internal
link to the SAO standard page resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0142DuVFXpWnjeQhZzT3N3nC
