### PR TITLE
docs(mch2022): explain why a Hatchery app's binary must be main.bin

### DIFF
--- a/content/en/docs/Badges/MCH2022/software-development/hatchery/_index.md
+++ b/content/en/docs/Badges/MCH2022/software-development/hatchery/_index.md
@@ -115,9 +115,40 @@ rename it. In case you're asking yourself: the *.bin file will be named the
 same way your firmware project is named in the top level "CMakeLists.txt" file:
 `project(main)`
 
+#### Why it has to be called `main.bin`
+
+The name is not a convention, and it is not AppFS being fussy. It is the badge
+firmware. When you install an ESP32 app from the Hatchery, the badge walks the
+list of files the app has and writes exactly one of them into AppFS: the one
+called `main.bin`. Every other file is downloaded to the app's folder as a data
+file. The check is a plain string comparison against a constant named
+`esp32_bin_fn` in
+[`main/app_management.c`](https://github.com/badgeteam/mch2022-firmware-esp32/blob/master/main/app_management.c)
+and
+[`main/menus/hatchery.c`](https://github.com/badgeteam/mch2022-firmware-esp32/blob/master/main/menus/hatchery.c).
+
+So an app whose binary is called `myapp.bin` installs without an error and then
+has nothing to run.
+
+AppFS itself does not care what your file was called. It stores apps under the
+**slug**, with the file name kept only as a title. That is why the name does
+not matter when you push over USB:
+
+```
+python3 app_push.py build/whatever.bin my_app "My App" 1 --run
+```
+
+Here `my_app` is the AppFS name and the thing an update has to match. Push the
+same name again and you replace the app, whatever the file on your computer was
+called. Only the Hatchery route, which goes through the badge's installer, needs
+`main.bin`.
+
 ### FPGA
 
-If you are uploading an FPGA project, please name it `bitstream.bin`.
+If you are uploading an FPGA project, please name it `bitstream.bin`. The same
+reasoning applies: the launcher opens `bitstream.bin` in the app's folder, and
+looks nowhere else. See
+[`main/menus/launcher.c`](https://github.com/badgeteam/mch2022-firmware-esp32/blob/master/main/menus/launcher.c).
 
 Once all the relevant stuff is there, click "Save" and if you are feeling
 brave, check the "Publish" box, this allows others to see your app in the


### PR DESCRIPTION
Closes #95.

The issue asked whether an AppFS app really has to be called `main.bin`, and
noted that "if that turns out to be true it should be documented". It is true,
but not for the reason the issue guessed.

## The answer

**AppFS does not care about file names.** It stores apps under a *slug*, and
keeps the file name only as a title.

**The badge firmware does care.** Installing an ESP32 app from the Hatchery
walks the app's file list and writes exactly one file into AppFS: the one whose
name equals the `esp32_bin_fn` constant, `"main.bin"`. Every other file is
downloaded into the app's folder as a data file. The comparison is a plain
`strcmp` in
[`main/app_management.c`](https://github.com/badgeteam/mch2022-firmware-esp32/blob/master/main/app_management.c)
and
[`main/menus/hatchery.c`](https://github.com/badgeteam/mch2022-firmware-esp32/blob/master/main/menus/hatchery.c).
So an app whose binary is `myapp.bin` installs without an error and then has
nothing to run — which matches the IRC report in the issue.

FPGA apps work the same way: the launcher opens `bitstream.bin` in the app
folder and looks nowhere else
([`main/menus/launcher.c`](https://github.com/badgeteam/mch2022-firmware-esp32/blob/master/main/menus/launcher.c)).

**Pushing over USB is unaffected.** `app_push.py <file> <name> <title>
<version>` takes the AppFS name as an argument, so the local file name is
irrelevant and an update matches on the name, not the file. No change is needed
in the tools or the Hatchery, which is the other half of what the issue asked.

## The change

A "Why it has to be called `main.bin`" subsection on the Hatchery page, with
the above, the `app_push.py` example, and links to the three source files. The
FPGA paragraph gets the same one-line reason.

`hugo --gc --minify` clean; all three source links return 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0142DuVFXpWnjeQhZzT3N3nC
