### PR TITLE
docs(mch2022): say which firmware the RGBW fix needs

### DIFF
--- a/content/en/docs/Badges/MCH2022/software-development/api/ws2812.md
+++ b/content/en/docs/Badges/MCH2022/software-development/api/ws2812.md
@@ -99,9 +99,13 @@ the five LEDs of the tilde add-on, then fades each color up and down,
 first across all five LEDs together and then one LED at a time. It is a
 short read and a good starting point for your own add-on.
 
-{{% alert title="RGBW mode does not work yet" color="warning" %}}
-Mode `2` is meant to select 32-bit RGBW output, but the RP2040 firmware
-falls through from that case straight into disabling the output, so the
-LEDs go dark instead. Use mode `1` until that is fixed upstream.
+{{% alert title="RGBW mode needs a firmware newer than 0x0C" color="warning" %}}
+Mode `2` selects 32-bit RGBW output. On every released RP2040 firmware up
+to and including `0x0C` it turns the LEDs off instead: the switch enables
+the output and then falls through into the disable case.
+
+[The fix](https://github.com/badgeteam/mch2022-firmware-rp2040/pull/22) is
+on `master` and is not in a release yet, so a badge you did not build the
+firmware for yourself still has this. Use mode `1` there.
 {{% /alert %}}
 


### PR DESCRIPTION
The page warned that RGBW mode was broken and would be fixed upstream.

[badgeteam/mch2022-firmware-rp2040#22](https://github.com/badgeteam/mch2022-firmware-rp2040/pull/22) fixed it, but the latest release is still `0x0C`, which does not carry it. A badge running a released firmware still goes dark on mode 2, so the warning stays — it just says which firmware now, and links the fix.

Worth revisiting when a firmware past `0x0C` ships.

`hugo --gc --minify` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0142DuVFXpWnjeQhZzT3N3nC