### PR TITLE
docs(hatchery): point the API pages at a URL that exists

### DIFF
--- a/content/en/docs/Hatchery/api.md
+++ b/content/en/docs/Hatchery/api.md
@@ -14,4 +14,4 @@ The badges communicate with the Hatchery server via an API, this page describes 
 }
 </style>
 
-{{< swaggerui src="https://hatchery.badge.team/docs/api-docs.json" >}}
+{{< swaggerui src="https://hatchery.badge.team/docs" >}}

--- a/content/en/docs/Hatchery/api_mch2022.md
+++ b/content/en/docs/Hatchery/api_mch2022.md
@@ -14,4 +14,4 @@ The badges communicate with the Hatchery server via an API, this page describes 
 }
 </style>
 
-{{< swaggerui src="https://mch2022.badge.team/docs/api-docs.json" >}}
+{{< swaggerui src="https://mch2022.badge.team/docs" >}}


### PR DESCRIPTION
Both Hatchery API pages have been showing **"Failed to load API definition"**
instead of an API.

They ask Swagger UI for `/docs/api-docs.json`, which neither host serves any
more:

```
404  https://hatchery.badge.team/docs/api-docs.json
404  https://mch2022.badge.team/docs/api-docs.json
200  https://hatchery.badge.team/docs      <- the OpenAPI document
200  https://mch2022.badge.team/docs
```

`/docs` returns the document itself, as `application/json` and with
`Access-Control-Allow-Origin: *`, so the browser can fetch it from badge.team.
Both pages now point there.

## The API itself is fine

Worth recording, since "Hatchery is broken" is easy to conclude from a page
that will not load. The chain the badge actually walks all answers correctly on
`mch2022.badge.team`:

| Endpoint | Result |
| --- | --- |
| `/v2/devices` | `mch2022`, `troopers23` |
| `/v2/mch2022/types` | esp32, python, ice40 |
| `/v2/mch2022/esp32/categories` | 9 categories |
| `/v2/mch2022/esp32/utility` | 11 apps |
| `/v2/mch2022/esp32/utility/esp32_test_app` | detail with `README.md`, `icon.png`, `main.bin` |

Note `hatchery.badge.team` and `mch2022.badge.team` are separate instances with
separate device lists — the MCH2022 badge only talks to the latter, and
`mch2022` is not a device on the former. That is why the two pages point at
different hosts, and both are now correct.

`hugo --gc --minify` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0142DuVFXpWnjeQhZzT3N3nC
