### PR TITLE
docs(contact): give the fourth board member a surname

### DIFF
--- a/content/en/Contact/_index.md
+++ b/content/en/Contact/_index.md
@@ -23,7 +23,7 @@ Our board consists of the following people:
  - Chairman: Paul Honig (ranzbak)
  - Treasurer: Jelle Haandrikman
  - Secretary: Emiel Bart
- - General board members: Anne Jan and Renze Nicolai
+ - General board members: Anne Jan Brouwer and Renze Nicolai
 
 ## Email
 


### PR DESCRIPTION
Every other name on the board list is a full name; "Anne Jan" was not. Now reads "Anne Jan Brouwer".